### PR TITLE
Replace for..of loop with while loop to avoid Internet Explorer syntax errors

### DIFF
--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -36,19 +36,22 @@
  */
 'use strict';
 
-function isIterable(obj) {
-  if (obj == null) {
-    return false;
-  }
-  return obj[Symbol.iterator] !== undefined;
-}
-
 // you can provide an iterable
 function FastBitSet(iterable) {
   this.words = []
-  if (isIterable(iterable)) {
-    for (var key of iterable) {
-      this.add(key);
+
+  if (iterable) {
+    if (Symbol && Symbol.iterator && iterable[Symbol.iterator] !== undefined) {
+      var iterator = iterable[Symbol.iterator]();
+      var current = iterator.next();
+      while(!current.done) {
+        this.add(current.value);
+        current = iterator.next();
+      }
+    } else {
+      for (var i=0;i<iterable.length;i++) {
+        this.add(iterable[i]);
+      }
     }
   }
 }


### PR DESCRIPTION
Unfortunately `for`..`of` loops are not supported at all in Internet Explorer, but this is the only part of FastBitSet.js that causes problems - forcing me to put it through Babel or another transpiler which most likely has other performance implications for an optimized library such as this one.

This PR makes a simple change to convert the `for`..`of` loop to use the underlying iterator in a `while` loop.

It also adds a fallback for browsers that do not support iterators properly... (looking at you IE).

The impact on performance should be negligible and only touches set initialization.

Thanks for a great library!