### PR TITLE
Make FastBitSet iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -189,6 +189,19 @@ FastBitSet.prototype.forEach = function(fnc) {
   }
 };
 
+// Returns an iterator of set bit locations (values)
+FastBitSet.prototype[Symbol.iterator] = function* () {
+  var c = this.words.length;
+  for (var k = 0; k < c; ++k) {
+    var w =  this.words[k];
+    while (w != 0) {
+      var t = w & -w;
+      yield (k << 5) + this.hammingWeight((t - 1) | 0);
+      w ^= t;
+    }
+  }
+};
+
 // Creates a copy of this bitmap
 FastBitSet.prototype.clone = function() {
   var clone = Object.create(FastBitSet.prototype);
@@ -413,9 +426,6 @@ FastBitSet.prototype.union_size = function(otherbitmap) {
   }
   return answer;
 };
-
-
-
 
 ///////////////
 

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -22,34 +22,35 @@
  *
  *  var c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
  *  c.difference(b); // from c, remove elements that are in b
+ *  c.change(b); // c will contain elements that are in b or in c, but not both
  *  var su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
- * c.union(b); // c will contain all elements that are in c and b
- * var s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
- * c.intersection(b); // c will only contain elements that are in both c and b
- * c = b.clone(); // create a (deep) copy of b and assign it to c.
- * c.equals(b); // check whether c and b are equal
+ *  c.union(b); // c will contain all elements that are in c and b
+ *  var s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
+ *  c.intersection(b); // c will only contain elements that are in both c and b
+ *  c = b.clone(); // create a (deep) copy of b and assign it to c.
+ *  c.equals(b); // check whether c and b are equal
  *
  *   See README.md file for a more complete description.
  *
  * You can install the library under node with the command line
  *   npm install fastbitset
  */
-'use strict';
+"use strict";
 
 // you can provide an iterable
 function FastBitSet(iterable) {
-  this.words = []
+  this.words = [];
 
   if (iterable) {
     if (Symbol && Symbol.iterator && iterable[Symbol.iterator] !== undefined) {
       var iterator = iterable[Symbol.iterator]();
       var current = iterator.next();
-      while(!current.done) {
+      while (!current.done) {
         this.add(current.value);
         current = iterator.next();
       }
     } else {
-      for (var i=0;i<iterable.length;i++) {
+      for (var i = 0; i < iterable.length; i++) {
         this.add(iterable[i]);
       }
     }
@@ -57,98 +58,95 @@ function FastBitSet(iterable) {
 }
 
 // Add the value (Set the bit at index to true)
-FastBitSet.prototype.add = function(index) {
+FastBitSet.prototype.add = function (index) {
   this.resize(index);
-  this.words[index >>> 5] |= 1 << index ;
+  this.words[index >>> 5] |= 1 << index;
 };
 
 // If the value was not in the set, add it, otherwise remove it (flip bit at index)
-FastBitSet.prototype.flip = function(index) {
+FastBitSet.prototype.flip = function (index) {
   this.resize(index);
-  this.words[index >>> 5] ^= 1 << index ;
+  this.words[index >>> 5] ^= 1 << index;
 };
 
 // Remove all values, reset memory usage
-FastBitSet.prototype.clear = function() {
-  this.words = []
+FastBitSet.prototype.clear = function () {
+  this.words = [];
 };
 
 // Set the bit at index to false
-FastBitSet.prototype.remove = function(index) {
+FastBitSet.prototype.remove = function (index) {
   this.resize(index);
-  this.words[index  >>> 5] &= ~(1 << index);
+  this.words[index >>> 5] &= ~(1 << index);
 };
 
 // Return true if no bit is set
-FastBitSet.prototype.isEmpty = function(index) {
+FastBitSet.prototype.isEmpty = function (index) {
   var c = this.words.length;
-  for (var  i = 0; i < c; i++) {
+  for (var i = 0; i < c; i++) {
     if (this.words[i] !== 0) return false;
   }
   return true;
 };
 
 // Is the value contained in the set? Is the bit at index true or false? Returns a boolean
-FastBitSet.prototype.has = function(index) {
-  return (this.words[index  >>> 5] & (1 << index)) !== 0;
+FastBitSet.prototype.has = function (index) {
+  return (this.words[index >>> 5] & (1 << index)) !== 0;
 };
 
 // Tries to add the value (Set the bit at index to true), return 1 if the
 // value was added, return 0 if the value was already present
-FastBitSet.prototype.checkedAdd = function(index) {
+FastBitSet.prototype.checkedAdd = function (index) {
   this.resize(index);
-  var word = this.words[index  >>> 5]
-  var newword = word | (1 << index)
-  this.words[index >>> 5] = newword
-  return (newword ^ word) >>> index
+  var word = this.words[index >>> 5];
+  var newword = word | (1 << index);
+  this.words[index >>> 5] = newword;
+  return (newword ^ word) >>> index;
 };
-
 
 // Reduce the memory usage to a minimum
-FastBitSet.prototype.trim = function(index) {
-  var nl = this.words.length
-  while ((nl > 0) && (this.words[nl - 1] === 0)) {
-      nl--;
+FastBitSet.prototype.trim = function (index) {
+  var nl = this.words.length;
+  while (nl > 0 && this.words[nl - 1] === 0) {
+    nl--;
   }
-  this.words = this.words.slice(0,nl);
+  this.words = this.words.slice(0, nl);
 };
 
-
 // Resize the bitset so that we can write a value at index
-FastBitSet.prototype.resize = function(index) {
-  var count = (index + 32) >>> 5;// just what is needed
-  for(var i = this.words.length; i < count; i++) this.words[i] = 0;
+FastBitSet.prototype.resize = function (index) {
+  var count = (index + 32) >>> 5; // just what is needed
+  for (var i = this.words.length; i < count; i++) this.words[i] = 0;
 };
 
 // fast function to compute the Hamming weight of a 32-bit unsigned integer
-FastBitSet.prototype.hammingWeight = function(v) {
-  v -= ((v >>> 1) & 0x55555555);// works with signed or unsigned shifts
+FastBitSet.prototype.hammingWeight = function (v) {
+  v -= (v >>> 1) & 0x55555555; // works with signed or unsigned shifts
   v = (v & 0x33333333) + ((v >>> 2) & 0x33333333);
-  return ((v + (v >>> 4) & 0xF0F0F0F) * 0x1010101) >>> 24;
+  return (((v + (v >>> 4)) & 0xf0f0f0f) * 0x1010101) >>> 24;
 };
 
-
 // fast function to compute the Hamming weight of four 32-bit unsigned integers
-FastBitSet.prototype.hammingWeight4 = function(v1,v2,v3,v4) {
-  v1 -= ((v1 >>> 1) & 0x55555555);// works with signed or unsigned shifts
-  v2 -= ((v2 >>> 1) & 0x55555555);// works with signed or unsigned shifts
-  v3 -= ((v3 >>> 1) & 0x55555555);// works with signed or unsigned shifts
-  v4 -= ((v4 >>> 1) & 0x55555555);// works with signed or unsigned shifts
+FastBitSet.prototype.hammingWeight4 = function (v1, v2, v3, v4) {
+  v1 -= (v1 >>> 1) & 0x55555555; // works with signed or unsigned shifts
+  v2 -= (v2 >>> 1) & 0x55555555; // works with signed or unsigned shifts
+  v3 -= (v3 >>> 1) & 0x55555555; // works with signed or unsigned shifts
+  v4 -= (v4 >>> 1) & 0x55555555; // works with signed or unsigned shifts
 
   v1 = (v1 & 0x33333333) + ((v1 >>> 2) & 0x33333333);
   v2 = (v2 & 0x33333333) + ((v2 >>> 2) & 0x33333333);
   v3 = (v3 & 0x33333333) + ((v3 >>> 2) & 0x33333333);
   v4 = (v4 & 0x33333333) + ((v4 >>> 2) & 0x33333333);
 
-  v1 = v1 + (v1 >>> 4) & 0xF0F0F0F;
-  v2 = v2 + (v2 >>> 4) & 0xF0F0F0F;
-  v3 = v3 + (v3 >>> 4) & 0xF0F0F0F;
-  v4 = v4 + (v4 >>> 4) & 0xF0F0F0F;
-  return (( (v1 + v2 + v3 + v4) * 0x1010101) >>> 24);
+  v1 = (v1 + (v1 >>> 4)) & 0xf0f0f0f;
+  v2 = (v2 + (v2 >>> 4)) & 0xf0f0f0f;
+  v3 = (v3 + (v3 >>> 4)) & 0xf0f0f0f;
+  v4 = (v4 + (v4 >>> 4)) & 0xf0f0f0f;
+  return ((v1 + v2 + v3 + v4) * 0x1010101) >>> 24;
 };
 
 // How many values stored in the set? How many set bits?
-FastBitSet.prototype.size = function() {
+FastBitSet.prototype.size = function () {
   var answer = 0;
   var c = this.words.length;
   var w = this.words;
@@ -160,12 +158,12 @@ FastBitSet.prototype.size = function() {
 };
 
 // Return an array with the set bit locations (values)
-FastBitSet.prototype.array = function() {
+FastBitSet.prototype.array = function () {
   var answer = new Array(this.size());
   var pos = 0 | 0;
   var c = this.words.length;
   for (var k = 0; k < c; ++k) {
-    var w =  this.words[k];
+    var w = this.words[k];
     while (w != 0) {
       var t = w & -w;
       answer[pos++] = (k << 5) + this.hammingWeight((t - 1) | 0);
@@ -175,12 +173,11 @@ FastBitSet.prototype.array = function() {
   return answer;
 };
 
-
 // Return an array with the set bit locations (values)
-FastBitSet.prototype.forEach = function(fnc) {
+FastBitSet.prototype.forEach = function (fnc) {
   var c = this.words.length;
   for (var k = 0; k < c; ++k) {
-    var w =  this.words[k];
+    var w = this.words[k];
     while (w != 0) {
       var t = w & -w;
       fnc((k << 5) + this.hammingWeight((t - 1) | 0));
@@ -193,7 +190,7 @@ FastBitSet.prototype.forEach = function(fnc) {
 FastBitSet.prototype[Symbol.iterator] = function* () {
   var c = this.words.length;
   for (var k = 0; k < c; ++k) {
-    var w =  this.words[k];
+    var w = this.words[k];
     while (w != 0) {
       var t = w & -w;
       yield (k << 5) + this.hammingWeight((t - 1) | 0);
@@ -203,7 +200,7 @@ FastBitSet.prototype[Symbol.iterator] = function* () {
 };
 
 // Creates a copy of this bitmap
-FastBitSet.prototype.clone = function() {
+FastBitSet.prototype.clone = function () {
   var clone = Object.create(FastBitSet.prototype);
   clone.words = this.words.slice();
   return clone;
@@ -211,8 +208,8 @@ FastBitSet.prototype.clone = function() {
 
 // Check if this bitset intersects with another one,
 // no bitmap is modified
-FastBitSet.prototype.intersects = function(otherbitmap) {
-  var newcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.intersects = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
   for (var k = 0 | 0; k < newcount; ++k) {
     if ((this.words[k] & otherbitmap.words[k]) !== 0) return true;
   }
@@ -221,8 +218,8 @@ FastBitSet.prototype.intersects = function(otherbitmap) {
 
 // Computes the intersection between this bitset and another one,
 // the current bitmap is modified  (and returned by the function)
-FastBitSet.prototype.intersection = function(otherbitmap) {
-  var newcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.intersection = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
   var k = 0 | 0;
   for (; k + 7 < newcount; k += 8) {
     this.words[k] &= otherbitmap.words[k];
@@ -245,8 +242,8 @@ FastBitSet.prototype.intersection = function(otherbitmap) {
 };
 
 // Computes the size of the intersection between this bitset and another one
-FastBitSet.prototype.intersection_size = function(otherbitmap) {
-  var newcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.intersection_size = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
   var answer = 0 | 0;
   for (var k = 0 | 0; k < newcount; ++k) {
     answer += this.hammingWeight(this.words[k] & otherbitmap.words[k]);
@@ -257,21 +254,21 @@ FastBitSet.prototype.intersection_size = function(otherbitmap) {
 
 // Computes the intersection between this bitset and another one,
 // a new bitmap is generated
-FastBitSet.prototype.new_intersection = function(otherbitmap) {
+FastBitSet.prototype.new_intersection = function (otherbitmap) {
   var answer = Object.create(FastBitSet.prototype);
-  var count = Math.min(this.words.length,otherbitmap.words.length);
+  var count = Math.min(this.words.length, otherbitmap.words.length);
   answer.words = new Array(count);
   var c = count;
   var k = 0 | 0;
-  for (; k + 7  < c; k += 8) {
-      answer.words[k] = this.words[k] & otherbitmap.words[k];
-      answer.words[k+1] = this.words[k+1] & otherbitmap.words[k+1];
-      answer.words[k+2] = this.words[k+2] & otherbitmap.words[k+2];
-      answer.words[k+3] = this.words[k+3] & otherbitmap.words[k+3];
-      answer.words[k+4] = this.words[k+4] & otherbitmap.words[k+4];
-      answer.words[k+5] = this.words[k+5] & otherbitmap.words[k+5];
-      answer.words[k+6] = this.words[k+6] & otherbitmap.words[k+6];
-      answer.words[k+7] = this.words[k+7] & otherbitmap.words[k+7];
+  for (; k + 7 < c; k += 8) {
+    answer.words[k] = this.words[k] & otherbitmap.words[k];
+    answer.words[k + 1] = this.words[k + 1] & otherbitmap.words[k + 1];
+    answer.words[k + 2] = this.words[k + 2] & otherbitmap.words[k + 2];
+    answer.words[k + 3] = this.words[k + 3] & otherbitmap.words[k + 3];
+    answer.words[k + 4] = this.words[k + 4] & otherbitmap.words[k + 4];
+    answer.words[k + 5] = this.words[k + 5] & otherbitmap.words[k + 5];
+    answer.words[k + 6] = this.words[k + 6] & otherbitmap.words[k + 6];
+    answer.words[k + 7] = this.words[k + 7] & otherbitmap.words[k + 7];
   }
   for (; k < c; ++k) {
     answer.words[k] = this.words[k] & otherbitmap.words[k];
@@ -281,8 +278,8 @@ FastBitSet.prototype.new_intersection = function(otherbitmap) {
 
 // Computes the intersection between this bitset and another one,
 // the current bitmap is modified
-FastBitSet.prototype.equals = function(otherbitmap) {
-  var mcount = Math.min(this.words.length , otherbitmap.words.length);
+FastBitSet.prototype.equals = function (otherbitmap) {
+  var mcount = Math.min(this.words.length, otherbitmap.words.length);
   for (var k = 0 | 0; k < mcount; ++k) {
     if (this.words[k] != otherbitmap.words[k]) return false;
   }
@@ -302,8 +299,8 @@ FastBitSet.prototype.equals = function(otherbitmap) {
 
 // Computes the difference between this bitset and another one,
 // the current bitset is modified (and returned by the function)
-FastBitSet.prototype.difference = function(otherbitmap) {
-  var newcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.difference = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
   var k = 0 | 0;
   for (; k + 7 < newcount; k += 8) {
     this.words[k] &= ~otherbitmap.words[k];
@@ -321,13 +318,61 @@ FastBitSet.prototype.difference = function(otherbitmap) {
   return this;
 };
 
+// Computes the difference between this bitset and another one,
+// a new bitmap is generated
+FastBitSet.prototype.new_difference = function (otherbitmap) {
+  return this.clone().difference(otherbitmap); // should be fast enough
+};
+
 // Computes the size of the difference between this bitset and another one
-FastBitSet.prototype.difference_size = function(otherbitmap) {
-  var newcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.difference_size = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
   var answer = 0 | 0;
   var k = 0 | 0;
   for (; k < newcount; ++k) {
-    answer += this.hammingWeight(this.words[k] & (~otherbitmap.words[k]));
+    answer += this.hammingWeight(this.words[k] & ~otherbitmap.words[k]);
+  }
+  var c = this.words.length;
+  for (; k < c; ++k) {
+    answer += this.hammingWeight(this.words[k]);
+  }
+  return answer;
+};
+
+// Computes the changed elements (XOR) between this bitset and another one,
+// the current bitset is modified (and returned by the function)
+FastBitSet.prototype.change = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
+  var k = 0 | 0;
+  for (; k + 7 < newcount; k += 8) {
+    this.words[k] ^= otherbitmap.words[k];
+    this.words[k + 1] ^= otherbitmap.words[k + 1];
+    this.words[k + 2] ^= otherbitmap.words[k + 2];
+    this.words[k + 3] ^= otherbitmap.words[k + 3];
+    this.words[k + 4] ^= otherbitmap.words[k + 4];
+    this.words[k + 5] ^= otherbitmap.words[k + 5];
+    this.words[k + 6] ^= otherbitmap.words[k + 6];
+    this.words[k + 7] ^= otherbitmap.words[k + 7];
+  }
+  for (; k < newcount; ++k) {
+    this.words[k] ^= otherbitmap.words[k];
+  }
+  return this;
+};
+
+// Computes the change between this bitset and another one,
+// a new bitmap is generated
+FastBitSet.prototype.new_change = function (otherbitmap) {
+  return this.clone().change(otherbitmap); // should be fast enough
+};
+
+// Computes the number of changed elements between this bitset and another one
+FastBitSet.prototype.change_size = function (otherbitmap) {
+  var newcount = Math.min(this.words.length, otherbitmap.words.length);
+  var answer = 0 | 0;
+  var k = 0 | 0;
+  for (; k < newcount; ++k) {
+    answer += this.hammingWeight(this.words[k] ^ otherbitmap.words[k]);
   }
   var c = this.words.length;
   for (; k < c; ++k) {
@@ -337,16 +382,16 @@ FastBitSet.prototype.difference_size = function(otherbitmap) {
 };
 
 // Returns a string representation
-FastBitSet.prototype.toString = function() {
-  return '{' + this.array().join(',') + '}';
+FastBitSet.prototype.toString = function () {
+  return "{" + this.array().join(",") + "}";
 };
 
 // Computes the union between this bitset and another one,
 // the current bitset is modified  (and returned by the function)
-FastBitSet.prototype.union = function(otherbitmap) {
-  var mcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.union = function (otherbitmap) {
+  var mcount = Math.min(this.words.length, otherbitmap.words.length);
   var k = 0 | 0;
-  for (; k + 7  < mcount; k += 8) {
+  for (; k + 7 < mcount; k += 8) {
     this.words[k] |= otherbitmap.words[k];
     this.words[k + 1] |= otherbitmap.words[k + 1];
     this.words[k + 2] |= otherbitmap.words[k + 2];
@@ -360,7 +405,7 @@ FastBitSet.prototype.union = function(otherbitmap) {
     this.words[k] |= otherbitmap.words[k];
   }
   if (this.words.length < otherbitmap.words.length) {
-    this.resize((otherbitmap.words.length  << 5) - 1);
+    this.resize((otherbitmap.words.length << 5) - 1);
     var c = otherbitmap.words.length;
     for (var k = mcount; k < c; ++k) {
       this.words[k] = otherbitmap.words[k];
@@ -369,58 +414,51 @@ FastBitSet.prototype.union = function(otherbitmap) {
   return this;
 };
 
-FastBitSet.prototype.new_union = function(otherbitmap) {
+FastBitSet.prototype.new_union = function (otherbitmap) {
   var answer = Object.create(FastBitSet.prototype);
-  var count = Math.max(this.words.length,otherbitmap.words.length);
+  var count = Math.max(this.words.length, otherbitmap.words.length);
   answer.words = new Array(count);
-  var mcount = Math.min(this.words.length,otherbitmap.words.length);
+  var mcount = Math.min(this.words.length, otherbitmap.words.length);
   var k = 0;
-  for (; k + 7  < mcount; k += 8) {
-      answer.words[k] = this.words[k] | otherbitmap.words[k];
-      answer.words[k+1] = this.words[k+1] | otherbitmap.words[k+1];
-      answer.words[k+2] = this.words[k+2] | otherbitmap.words[k+2];
-      answer.words[k+3] = this.words[k+3] | otherbitmap.words[k+3];
-      answer.words[k+4] = this.words[k+4] | otherbitmap.words[k+4];
-      answer.words[k+5] = this.words[k+5] | otherbitmap.words[k+5];
-      answer.words[k+6] = this.words[k+6] | otherbitmap.words[k+6];
-      answer.words[k+7] = this.words[k+7] | otherbitmap.words[k+7];
+  for (; k + 7 < mcount; k += 8) {
+    answer.words[k] = this.words[k] | otherbitmap.words[k];
+    answer.words[k + 1] = this.words[k + 1] | otherbitmap.words[k + 1];
+    answer.words[k + 2] = this.words[k + 2] | otherbitmap.words[k + 2];
+    answer.words[k + 3] = this.words[k + 3] | otherbitmap.words[k + 3];
+    answer.words[k + 4] = this.words[k + 4] | otherbitmap.words[k + 4];
+    answer.words[k + 5] = this.words[k + 5] | otherbitmap.words[k + 5];
+    answer.words[k + 6] = this.words[k + 6] | otherbitmap.words[k + 6];
+    answer.words[k + 7] = this.words[k + 7] | otherbitmap.words[k + 7];
   }
   for (; k < mcount; ++k) {
-      answer.words[k] = this.words[k] | otherbitmap.words[k];
+    answer.words[k] = this.words[k] | otherbitmap.words[k];
   }
   var c = this.words.length;
   for (var k = mcount; k < c; ++k) {
-      answer.words[k] = this.words[k] ;
+    answer.words[k] = this.words[k];
   }
   var c2 = otherbitmap.words.length;
   for (var k = mcount; k < c2; ++k) {
-      answer.words[k] = otherbitmap.words[k] ;
+    answer.words[k] = otherbitmap.words[k];
   }
   return answer;
 };
 
-
-// Computes the difference between this bitset and another one,
-// a new bitmap is generated
-FastBitSet.prototype.new_difference = function(otherbitmap) {
-  return this.clone().difference(otherbitmap);// should be fast enough
-};
-
 // Computes the size union between this bitset and another one
-FastBitSet.prototype.union_size = function(otherbitmap) {
-  var mcount = Math.min(this.words.length,otherbitmap.words.length);
+FastBitSet.prototype.union_size = function (otherbitmap) {
+  var mcount = Math.min(this.words.length, otherbitmap.words.length);
   var answer = 0 | 0;
   for (var k = 0 | 0; k < mcount; ++k) {
     answer += this.hammingWeight(this.words[k] | otherbitmap.words[k]);
   }
   if (this.words.length < otherbitmap.words.length) {
     var c = otherbitmap.words.length;
-    for (var k = this.words.length ; k < c; ++k) {
+    for (var k = this.words.length; k < c; ++k) {
       answer += this.hammingWeight(otherbitmap.words[k] | 0);
     }
   } else {
     var c = this.words.length;
-    for (var k = otherbitmap.words.length ; k < c; ++k) {
+    for (var k = otherbitmap.words.length; k < c; ++k) {
       answer += this.hammingWeight(this.words[k] | 0);
     }
   }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are using node.js, you need to import the module:
 ```javascript
 var FastBitSet = require("fastbitset");
 var b = new FastBitSet();// initially empty
-b.set(1);// add the value "1"
+b.add(1);// add the value "1"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ b.add(10);
 b.array(); // would return [1,2,10]
 var c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
 c.difference(b); // from c, remove elements that are in b
+c.change(b); // c will contain all elements that are in b or in c, but not both (elements that changed)
 var su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
 c.union(b); // c will contain all elements that are in c and b
 var out1 = c.new_union(b); // creates a new bitmap that contains everything in c and b
 var out2 = c.new_intersection(b); // creates a new bitmap that contains everything that is in both c and b
+var out3 = c.new_change(b); // creates a new bitmap that contains everything in b or in c, but not both
 var s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
-var s3 = c.difference_size(b);// compute the size of the difference (bitsets are unchanged)
+var s2 = c.difference_size(b);// compute the size of the difference (bitsets are unchanged)
+var s3 = c.change_size(b); // compute the number of elements that are in b but not c, or vice versa
 c.intersects(b); // return true if c intersects with b
 c.intersection(b); // c will only contain elements that are in both c and b
 c = b.clone(); // create a (deep) copy of b and assign it to c.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ c.intersection(b); // c will only contain elements that are in both c and b
 c = b.clone(); // create a (deep) copy of b and assign it to c.
 c.equals(b); // checks whether c and b are equal
 c.forEach(fnc); // execute fnc on each value stored in c
-for (const x of c) fnc(c); // execute fnc on each value stored in c (allows early exit with break)
+for (const x of c) fnc(x); // execute fnc on each value stored in c (allows early exit with break)
 c.trim(); // reduce the memory usage of the bitmap if possible, the content remains the same
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ faster than a generic set implementation. In particular, a BitSet has fast suppo
 operations (union, difference, intersection).
 
 The FastBitSet.js implementation optimizes for speed. It can be several times faster than competitive alternatives. It is also entirely
-dynamic, and has functions to minimize the memory usage. It should be supported by most of the modern 
+dynamic, and has functions to minimize the memory usage. It should be supported by most of the modern
 browsers and JavaScript engines.  It is ideal for maintaining sets of integers when performance matters.
 
 
@@ -42,6 +42,7 @@ c.intersection(b); // c will only contain elements that are in both c and b
 c = b.clone(); // create a (deep) copy of b and assign it to c.
 c.equals(b); // checks whether c and b are equal
 c.forEach(fnc); // execute fnc on each value stored in c
+for (const x of c) fnc(c); // execute fnc on each value stored in c (allows early exit with break)
 c.trim(); // reduce the memory usage of the bitmap if possible, the content remains the same
 ```
 
@@ -203,7 +204,7 @@ Set x 76,784,958 ops/sec ±0.01% (104 runs sampled)
 You might also like...
 ===
 
-If you like this library, you might also like 
+If you like this library, you might also like
 - https://github.com/lemire/TypedFastBitSet.js
 - https://github.com/lemire/FastPriorityQueue.js
 - https://github.com/lemire/StablePriorityQueue.js

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -1,9 +1,9 @@
 /* This script expects node.js  and mocha */
 
-'use strict';
+"use strict";
 
-describe('BitSet', function() {
-  var FastBitSet = require('../FastBitSet.js');
+describe("BitSet", function () {
+  var FastBitSet = require("../FastBitSet.js");
 
   function arraysEquals(a, b) {
     var i = a.length;
@@ -12,136 +12,159 @@ describe('BitSet', function() {
       if (a[i] !== b[i]) return false;
     }
     return true;
-  };
+  }
 
-  it('Testing set/get/clear', function() {
+  it("Testing set/get/clear", function () {
     var mb = new FastBitSet();
     var N = 1024;
-    for (var i = 0  ; i < N ; i ++) {
+    for (var i = 0; i < N; i++) {
       mb.add(i);
-      if (!mb.has(i)) throw 'set did not register';
-      if (mb.size() != i + 1) throw ('cardinality bug ' + i + ' ' + mb.size());
-      for (var j = 0 ; j <= i; j++) {
-        if (!mb.has(j)) throw 'bad get';
+      if (!mb.has(i)) throw "set did not register";
+      if (mb.size() != i + 1) throw "cardinality bug " + i + " " + mb.size();
+      for (var j = 0; j <= i; j++) {
+        if (!mb.has(j)) throw "bad get";
       }
-      for (var j = i + 1 ; j < N; j++) {
-        if (mb.has(j)) throw 'bad get';
+      for (var j = i + 1; j < N; j++) {
+        if (mb.has(j)) throw "bad get";
       }
     }
-    for (var i = N - 1  ; i >= 0  ; i --) {
+    for (var i = N - 1; i >= 0; i--) {
       mb.remove(i);
-      if (mb.has(i)) throw 'clear did not register';
-      if (mb.size() != i) throw ('cardinality bug ' + i + ' ' + mb.size());
-      for (var j = 0 ; j < i; j++) {
-        if (!mb.has(j)) throw 'bad get';
+      if (mb.has(i)) throw "clear did not register";
+      if (mb.size() != i) throw "cardinality bug " + i + " " + mb.size();
+      for (var j = 0; j < i; j++) {
+        if (!mb.has(j)) throw "bad get";
       }
-      for (var j = i ; j < N; j++) {
-        if (mb.has(j)) throw 'bad get';
+      for (var j = i; j < N; j++) {
+        if (mb.has(j)) throw "bad get";
       }
     }
-
   });
 
-  it('Testing init', function() {
-    var ai = [1,2,4,5,10];
+  it("Testing init", function () {
+    var ai = [1, 2, 4, 5, 10];
     var mb = new FastBitSet(ai);
-    if (mb.size() != ai.length) throw 'bad init';
+    if (mb.size() != ai.length) throw "bad init";
   });
 
-
-  it('Testing array', function() {
-      for(var i = 0; i < 128; i++) {
-        for(var j = 0; j < i; j++) {
-          var ai = [j,i];
-          var mb = new FastBitSet(ai);
-          if (!arraysEquals(ai, mb.array())) throw 'bad array';
-        }
+  it("Testing array", function () {
+    for (var i = 0; i < 128; i++) {
+      for (var j = 0; j < i; j++) {
+        var ai = [j, i];
+        var mb = new FastBitSet(ai);
+        if (!arraysEquals(ai, mb.array())) throw "bad array";
       }
+    }
   });
 
-  it('Testing card', function() {
-      for(var offset = 1; offset <32; offset++) {
-        var mb = new FastBitSet();
-        for(var i = 0; i < 1024; i++) {
-          mb.add(i * offset);
-          if(mb.size() != i+1) throw "bad card "+i+" offset = "+offset+" "+mb.size();
-        }
+  it("Testing card", function () {
+    for (var offset = 1; offset < 32; offset++) {
+      var mb = new FastBitSet();
+      for (var i = 0; i < 1024; i++) {
+        mb.add(i * offset);
+        if (mb.size() != i + 1)
+          throw "bad card " + i + " offset = " + offset + " " + mb.size();
       }
+    }
   });
 
-
-  it('Testing values', function() {
-    var ai = [1,2,4,5,10];
+  it("Testing values", function () {
+    var ai = [1, 2, 4, 5, 10];
     var mb = new FastBitSet(ai);
     var a = mb.array();
-    if (!arraysEquals(a, ai)) throw 'bad values';
-    for (var i = 0; i < a.length; i ++) {
-      if (!mb.has(a[i])) throw 'bad enumeration';
+    if (!arraysEquals(a, ai)) throw "bad values";
+    for (var i = 0; i < a.length; i++) {
+      if (!mb.has(a[i])) throw "bad enumeration";
     }
-
   });
 
-  it('Testing clone', function() {
-    var ai = [1,2,4,5,10,31,32,63,64];
+  it("Testing clone", function () {
+    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64];
     var mb = new FastBitSet(ai);
     var mb2 = mb.clone();
     var a = mb2.array();
-    if (!arraysEquals(a, ai)) throw 'bad values';
-    if (!mb.equals(mb2)) throw 'bad clone';
+    if (!arraysEquals(a, ai)) throw "bad values";
+    if (!mb.equals(mb2)) throw "bad clone";
   });
-  it('Testing trim', function() {
-    var ai = [1,2,4,5,10,31,32,63,64,127,2030];
+
+  it("Testing trim", function () {
+    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
     var mb = new FastBitSet(ai);
     var mb2 = mb.clone();
     mb2.trim();
     var a = mb2.array();
-    if (!arraysEquals(a, ai)) throw 'bad values';
-    if (!mb.equals(mb2)) throw 'bad trim/clone';
+    if (!arraysEquals(a, ai)) throw "bad values";
+    if (!mb.equals(mb2)) throw "bad trim/clone";
   });
 
-  it('Testing intersection', function() {
-    var a1 = [1,2,4,5,10];
-    var a2 = [1,2,4,5,10,100,1000];
+  it("Testing iterator", function () {
+    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
+    var mb = new FastBitSet(ai);
+    var arr = [];
+    for (var x of mb) arr.push(x);
+    if (!arraysEquals(ai, arr)) throw "bad iterator";
+    var mb2 = new FastBitSet(mb);
+    if (!mb.equals(mb2)) throw "bad iterator/init";
+  });
+
+  it("Testing intersection", function () {
+    var a1 = [1, 2, 4, 5, 10];
+    var a2 = [1, 2, 4, 5, 10, 100, 1000];
     var mb1 = new FastBitSet(a1);
     var mb2 = new FastBitSet(a2);
     var pinter = mb1.intersection_size(mb2);
     mb1.intersection(mb2);
-    if (pinter != mb1.size()) throw 'bad size';
+    if (pinter != mb1.size()) throw "bad size";
     var a = mb1.array();
-    if (!arraysEquals(a, a1)) throw 'bad values';
+    if (!arraysEquals(a, a1)) throw "bad values";
     var pinter = mb2.intersection_size(mb1);
     mb2.intersection(mb1);
-    if (pinter != mb2.size()) throw 'bad size';
-    if (!mb1.equals(mb2)) throw 'bad intersect';
+    if (pinter != mb2.size()) throw "bad size";
+    if (!mb1.equals(mb2)) throw "bad intersect";
   });
 
-  it('Testing difference', function() {
-    var a1 = [1,2,4,5,10];
-    var a2 = [1,2,4,5,10,100,1000];
+  it("Testing difference", function () {
+    var a1 = [1, 2, 4, 5, 10];
+    var a2 = [1, 2, 4, 5, 10, 100, 1000];
     var mb1 = new FastBitSet(a1);
     var mb2 = new FastBitSet(a2);
     mb1.difference(mb2);
-    if (!mb1.isEmpty()) throw 'bad diff';
+    if (!mb1.isEmpty()) throw "bad diff";
     mb1 = new FastBitSet(a1);
     mb2.difference(mb1);
-    if (mb2.size() != 2) throw 'bad diff';
+    if (mb2.size() != 2) throw "bad diff";
   });
 
-  it('Testing union', function() {
-    var a1 = [1,2,4,5,10];
-    var a2 = [1,2,4,5,10,100,1000];
+  it("Testing union", function () {
+    var a1 = [1, 2, 4, 5, 10];
+    var a2 = [1, 2, 4, 5, 10, 100, 1000];
     var mb1 = new FastBitSet(a1);
     var mb2 = new FastBitSet(a2);
     var punion = mb1.union_size(mb2);
     mb1.union(mb2);
-    if (punion != mb1.size()) throw 'bad size';
-    if (!mb1.equals(mb2)) throw 'bad diff';
+    if (punion != mb1.size()) throw "bad size";
+    if (!mb1.equals(mb2)) throw "bad diff";
     mb1 = new FastBitSet(a1);
     var punion = mb2.union_size(mb1);
     mb2.union(mb1);
-    if (punion != mb2.size()) throw 'bad size';
+    if (punion != mb2.size()) throw "bad size";
     var a = mb2.array();
-    if (!arraysEquals(a, a2)) throw 'bad values';
+    if (!arraysEquals(a, a2)) throw "bad values";
   });
 
+  it("Testing change", function () {
+    var a1 = [1, 2, 4, 5, 10];
+    var a2 = [1, 2, 4, 5, 10, 100, 1000];
+    var ch = [100, 1000];
+    var mb1 = new FastBitSet(a1);
+    var mb2 = new FastBitSet(a2);
+    if (mb1.change_size(mb2) !== mb2.change_size(mb1)) throw "bad change_size";
+    if (!mb1.new_change(mb2).equals(mb2.new_change(mb1)))
+      throw "bad new_change";
+    var arr = mb1.change(mb2).array();
+    if (!arraysEquals(arr, ch)) throw "bad change";
+    var mb1 = new FastBitSet(a1);
+    var arr = mb2.change(mb1).array();
+    if (!arraysEquals(arr, ch)) throw "bad change";
+  });
 });


### PR DESCRIPTION
This pull request adds a `Symbol.iterator` property to `FastBitSet`, which makes the sets iterable. That means we can do things like
```javascript
const bs = new BitSet
bs.add(1)
bs.add(2)
bs.add(3)

// Outputs each element of bs (up to max) to the console
const max = 2;
for (const x of bs) {
  console.log(x);
  if (x > max) {
    break;
  }
}
// outputs 1 and 2, but not 3
```
The above differs from `forEach` in two major ways.
  * we can break out of a `for...of` loop
  * the scope inside the for loop is intuitive

Another thing that cannot be done with a `forEach` loop is create other iterators
```javascript
function* gen( func) {
  for (const x of bs) {
    yield func(x)
  }  
}



const squaresGen = gen(x => x**2)

squaresGen.next().value  // 1
squaresGen.next().value  // 4
squaresGen.next().value  // 9 
```

We can also take advantage of spread operations like
```javascript
func(...bs)  // executes func(1,2,3)
```