### PR TITLE
new method and improvements

### DIFF
--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -20,7 +20,8 @@
  *  b.array(); // would return [1,2,10]
  *
  *  let c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
- *  c.difference(b); // from c, remove elements that are in b
+ *  c.difference(b); // from c, remove elements that are in b (modifies c)
+ *  c.difference2(b); // from c, remove elements that are in b (modifies b)
  *  c.change(b); // c will contain elements that are in b or in c, but not both
  *  const su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
  *  c.union(b); // c will contain all elements that are in c and b
@@ -304,6 +305,8 @@ FastBitSet.prototype.equals = function (otherbitmap) {
 
 // Computes the difference between this bitset and another one,
 // the current bitset is modified (and returned by the function)
+// (for this set A and other set B,
+//   this computes A = A - B  and returns A)
 FastBitSet.prototype.difference = function (otherbitmap) {
   const newcount = Math.min(this.words.length, otherbitmap.words.length);
   let k = 0 | 0;
@@ -324,7 +327,9 @@ FastBitSet.prototype.difference = function (otherbitmap) {
 };
 
 // Computes the difference between this bitset and another one,
-// the current bitset is modified (and returned by the function)
+// the other bitset is modified (and returned by the function)
+// (for this set A and other set B,
+//   this computes B = A - B  and returns B)
 FastBitSet.prototype.difference2 = function (otherbitmap) {
   const newcount = Math.min(this.words.length, otherbitmap.words.length);
   let k = 0 | 0;

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -79,7 +79,7 @@ FastBitSet.prototype.flip = function (index) {
 
 // Remove all values, reset memory usage
 FastBitSet.prototype.clear = function () {
-  this.words = [];
+  this.words.length = 0;
 };
 
 // Set the bit at index to false

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -331,9 +331,9 @@ FastBitSet.prototype.difference = function (otherbitmap) {
 // (for this set A and other set B,
 //   this computes B = A - B  and returns B)
 FastBitSet.prototype.difference2 = function (otherbitmap) {
-  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  const mincount = Math.min(this.words.length, otherbitmap.words.length);
   let k = 0 | 0;
-  for (; k + 7 < newcount; k += 8) {
+  for (; k + 7 < mincount; k += 8) {
     otherbitmap.words[k] = this.words[k] & ~otherbitmap.words[k];
     otherbitmap.words[k + 1] = this.words[k + 1] & ~otherbitmap.words[k + 1];
     otherbitmap.words[k + 2] = this.words[k + 2] & ~otherbitmap.words[k + 2];
@@ -343,9 +343,14 @@ FastBitSet.prototype.difference2 = function (otherbitmap) {
     otherbitmap.words[k + 6] = this.words[k + 6] & ~otherbitmap.words[k + 6];
     otherbitmap.words[k + 7] = this.words[k + 7] & ~otherbitmap.words[k + 7];
   }
-  for (; k < newcount; ++k) {
+  for (; k < mincount; ++k) {
     otherbitmap.words[k] = this.words[k] & ~otherbitmap.words[k];
   }
+  // remaining words are all part of difference
+  for (k = this.words.length - 1; k >= mincount; --k) {
+    otherbitmap.words[k] = this.words[k];
+  }
+  otherbitmap.words = otherbitmap.words.slice(0, this.words.length);
   return otherbitmap;
 };
 

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -10,8 +10,8 @@
  * like typed arrays.
  *
  * Simple usage :
- *  // var FastBitSet = require("fastbitset");// if you use node
- *  var b = new FastBitSet();// initially empty
+ *  // const FastBitSet = require("fastbitset");// if you use node
+ *  const b = new FastBitSet();// initially empty
  *  b.add(1);// add the value "1"
  *  b.has(1); // check that the value is present! (will return true)
  *  b.add(2);
@@ -19,12 +19,12 @@
  *  b.add(10);
  *  b.array(); // would return [1,2,10]
  *
- *  var c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
+ *  let c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
  *  c.difference(b); // from c, remove elements that are in b
  *  c.change(b); // c will contain elements that are in b or in c, but not both
- *  var su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
+ *  const su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
  *  c.union(b); // c will contain all elements that are in c and b
- *  var s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
+ *  const s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
  *  c.intersection(b); // c will only contain elements that are in both c and b
  *  c = b.clone(); // create a (deep) copy of b and assign it to c.
  *  c.equals(b); // check whether c and b are equal
@@ -43,19 +43,26 @@ function FastBitSet(iterable) {
 
   if (iterable) {
     if (Symbol && Symbol.iterator && iterable[Symbol.iterator] !== undefined) {
-      var iterator = iterable[Symbol.iterator]();
-      var current = iterator.next();
+      const iterator = iterable[Symbol.iterator]();
+      let current = iterator.next();
       while (!current.done) {
         this.add(current.value);
         current = iterator.next();
       }
     } else {
-      for (var i = 0; i < iterable.length; i++) {
+      for (let i = 0; i < iterable.length; i++) {
         this.add(iterable[i]);
       }
     }
   }
 }
+
+// Creates a bitmap from words
+FastBitSet.prototype.fromWords = function (words) {
+  const bitSet = Object.create(FastBitSet.prototype);
+  bitSet.words = words;
+  return bitSet;
+};
 
 // Add the value (Set the bit at index to true)
 FastBitSet.prototype.add = function (index) {
@@ -82,8 +89,8 @@ FastBitSet.prototype.remove = function (index) {
 
 // Return true if no bit is set
 FastBitSet.prototype.isEmpty = function (index) {
-  var c = this.words.length;
-  for (var i = 0; i < c; i++) {
+  const c = this.words.length;
+  for (let i = 0; i < c; i++) {
     if (this.words[i] !== 0) return false;
   }
   return true;
@@ -98,15 +105,15 @@ FastBitSet.prototype.has = function (index) {
 // value was added, return 0 if the value was already present
 FastBitSet.prototype.checkedAdd = function (index) {
   this.resize(index);
-  var word = this.words[index >>> 5];
-  var newword = word | (1 << index);
+  const word = this.words[index >>> 5];
+  const newword = word | (1 << index);
   this.words[index >>> 5] = newword;
   return (newword ^ word) >>> index;
 };
 
 // Reduce the memory usage to a minimum
 FastBitSet.prototype.trim = function (index) {
-  var nl = this.words.length;
+  let nl = this.words.length;
   while (nl > 0 && this.words[nl - 1] === 0) {
     nl--;
   }
@@ -115,8 +122,8 @@ FastBitSet.prototype.trim = function (index) {
 
 // Resize the bitset so that we can write a value at index
 FastBitSet.prototype.resize = function (index) {
-  var count = (index + 32) >>> 5; // just what is needed
-  for (var i = this.words.length; i < count; i++) this.words[i] = 0;
+  const count = (index + 32) >>> 5; // just what is needed
+  for (let i = this.words.length; i < count; i++) this.words[i] = 0;
 };
 
 // fast function to compute the Hamming weight of a 32-bit unsigned integer
@@ -147,11 +154,10 @@ FastBitSet.prototype.hammingWeight4 = function (v1, v2, v3, v4) {
 
 // How many values stored in the set? How many set bits?
 FastBitSet.prototype.size = function () {
-  var answer = 0;
-  var c = this.words.length;
-  var w = this.words;
-  var i = 0;
-  for (; i < c; i++) {
+  let answer = 0;
+  const c = this.words.length;
+  const w = this.words;
+  for (let i = 0; i < c; i++) {
     answer += this.hammingWeight(w[i]);
   }
   return answer;
@@ -159,13 +165,13 @@ FastBitSet.prototype.size = function () {
 
 // Return an array with the set bit locations (values)
 FastBitSet.prototype.array = function () {
-  var answer = new Array(this.size());
-  var pos = 0 | 0;
-  var c = this.words.length;
-  for (var k = 0; k < c; ++k) {
-    var w = this.words[k];
+  const answer = new Array(this.size());
+  let pos = 0 | 0;
+  const c = this.words.length;
+  for (let k = 0; k < c; ++k) {
+    let w = this.words[k];
     while (w != 0) {
-      var t = w & -w;
+      const t = w & -w;
       answer[pos++] = (k << 5) + this.hammingWeight((t - 1) | 0);
       w ^= t;
     }
@@ -175,11 +181,11 @@ FastBitSet.prototype.array = function () {
 
 // Return an array with the set bit locations (values)
 FastBitSet.prototype.forEach = function (fnc) {
-  var c = this.words.length;
-  for (var k = 0; k < c; ++k) {
-    var w = this.words[k];
+  const c = this.words.length;
+  for (let k = 0; k < c; ++k) {
+    let w = this.words[k];
     while (w != 0) {
-      var t = w & -w;
+      const t = w & -w;
       fnc((k << 5) + this.hammingWeight((t - 1) | 0));
       w ^= t;
     }
@@ -188,11 +194,11 @@ FastBitSet.prototype.forEach = function (fnc) {
 
 // Returns an iterator of set bit locations (values)
 FastBitSet.prototype[Symbol.iterator] = function* () {
-  var c = this.words.length;
-  for (var k = 0; k < c; ++k) {
-    var w = this.words[k];
+  const c = this.words.length;
+  for (let k = 0; k < c; ++k) {
+    let w = this.words[k];
     while (w != 0) {
-      var t = w & -w;
+      const t = w & -w;
       yield (k << 5) + this.hammingWeight((t - 1) | 0);
       w ^= t;
     }
@@ -201,7 +207,7 @@ FastBitSet.prototype[Symbol.iterator] = function* () {
 
 // Creates a copy of this bitmap
 FastBitSet.prototype.clone = function () {
-  var clone = Object.create(FastBitSet.prototype);
+  const clone = Object.create(FastBitSet.prototype);
   clone.words = this.words.slice();
   return clone;
 };
@@ -209,8 +215,8 @@ FastBitSet.prototype.clone = function () {
 // Check if this bitset intersects with another one,
 // no bitmap is modified
 FastBitSet.prototype.intersects = function (otherbitmap) {
-  var newcount = Math.min(this.words.length, otherbitmap.words.length);
-  for (var k = 0 | 0; k < newcount; ++k) {
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  for (let k = 0 | 0; k < newcount; ++k) {
     if ((this.words[k] & otherbitmap.words[k]) !== 0) return true;
   }
   return false;
@@ -219,8 +225,8 @@ FastBitSet.prototype.intersects = function (otherbitmap) {
 // Computes the intersection between this bitset and another one,
 // the current bitmap is modified  (and returned by the function)
 FastBitSet.prototype.intersection = function (otherbitmap) {
-  var newcount = Math.min(this.words.length, otherbitmap.words.length);
-  var k = 0 | 0;
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0 | 0;
   for (; k + 7 < newcount; k += 8) {
     this.words[k] &= otherbitmap.words[k];
     this.words[k + 1] &= otherbitmap.words[k + 1];
@@ -234,8 +240,8 @@ FastBitSet.prototype.intersection = function (otherbitmap) {
   for (; k < newcount; ++k) {
     this.words[k] &= otherbitmap.words[k];
   }
-  var c = this.words.length;
-  for (var k = newcount; k < c; ++k) {
+  const c = this.words.length;
+  for (k = newcount; k < c; ++k) {
     this.words[k] = 0;
   }
   return this;
@@ -243,9 +249,9 @@ FastBitSet.prototype.intersection = function (otherbitmap) {
 
 // Computes the size of the intersection between this bitset and another one
 FastBitSet.prototype.intersection_size = function (otherbitmap) {
-  var newcount = Math.min(this.words.length, otherbitmap.words.length);
-  var answer = 0 | 0;
-  for (var k = 0 | 0; k < newcount; ++k) {
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  let answer = 0 | 0;
+  for (let k = 0 | 0; k < newcount; ++k) {
     answer += this.hammingWeight(this.words[k] & otherbitmap.words[k]);
   }
 
@@ -255,12 +261,11 @@ FastBitSet.prototype.intersection_size = function (otherbitmap) {
 // Computes the intersection between this bitset and another one,
 // a new bitmap is generated
 FastBitSet.prototype.new_intersection = function (otherbitmap) {
-  var answer = Object.create(FastBitSet.prototype);
-  var count = Math.min(this.words.length, otherbitmap.words.length);
+  const answer = Object.create(FastBitSet.prototype);
+  const count = Math.min(this.words.length, otherbitmap.words.length);
   answer.words = new Array(count);
-  var c = count;
-  var k = 0 | 0;
-  for (; k + 7 < c; k += 8) {
+  let k = 0 | 0;
+  for (; k + 7 < count; k += 8) {
     answer.words[k] = this.words[k] & otherbitmap.words[k];
     answer.words[k + 1] = this.words[k + 1] & otherbitmap.words[k + 1];
     answer.words[k + 2] = this.words[k + 2] & otherbitmap.words[k + 2];
@@ -270,7 +275,7 @@ FastBitSet.prototype.new_intersection = function (otherbitmap) {
     answer.words[k + 6] = this.words[k + 6] & otherbitmap.words[k + 6];
     answer.words[k + 7] = this.words[k + 7] & otherbitmap.words[k + 7];
   }
-  for (; k < c; ++k) {
+  for (; k < count; ++k) {
     answer.words[k] = this.words[k] & otherbitmap.words[k];
   }
   return answer;
@@ -279,18 +284,18 @@ FastBitSet.prototype.new_intersection = function (otherbitmap) {
 // Computes the intersection between this bitset and another one,
 // the current bitmap is modified
 FastBitSet.prototype.equals = function (otherbitmap) {
-  var mcount = Math.min(this.words.length, otherbitmap.words.length);
-  for (var k = 0 | 0; k < mcount; ++k) {
+  const mcount = Math.min(this.words.length, otherbitmap.words.length);
+  for (let k = 0 | 0; k < mcount; ++k) {
     if (this.words[k] != otherbitmap.words[k]) return false;
   }
   if (this.words.length < otherbitmap.words.length) {
-    var c = otherbitmap.words.length;
-    for (var k = this.words.length; k < c; ++k) {
+    const c = otherbitmap.words.length;
+    for (let k = this.words.length; k < c; ++k) {
       if (otherbitmap.words[k] != 0) return false;
     }
   } else if (otherbitmap.words.length < this.words.length) {
-    var c = this.words.length;
-    for (var k = otherbitmap.words.length; k < c; ++k) {
+    const c = this.words.length;
+    for (let k = otherbitmap.words.length; k < c; ++k) {
       if (this.words[k] != 0) return false;
     }
   }
@@ -300,8 +305,8 @@ FastBitSet.prototype.equals = function (otherbitmap) {
 // Computes the difference between this bitset and another one,
 // the current bitset is modified (and returned by the function)
 FastBitSet.prototype.difference = function (otherbitmap) {
-  var newcount = Math.min(this.words.length, otherbitmap.words.length);
-  var k = 0 | 0;
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0 | 0;
   for (; k + 7 < newcount; k += 8) {
     this.words[k] &= ~otherbitmap.words[k];
     this.words[k + 1] &= ~otherbitmap.words[k + 1];
@@ -326,13 +331,13 @@ FastBitSet.prototype.new_difference = function (otherbitmap) {
 
 // Computes the size of the difference between this bitset and another one
 FastBitSet.prototype.difference_size = function (otherbitmap) {
-  var newcount = Math.min(this.words.length, otherbitmap.words.length);
-  var answer = 0 | 0;
-  var k = 0 | 0;
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  let answer = 0 | 0;
+  let k = 0 | 0;
   for (; k < newcount; ++k) {
     answer += this.hammingWeight(this.words[k] & ~otherbitmap.words[k]);
   }
-  var c = this.words.length;
+  const c = this.words.length;
   for (; k < c; ++k) {
     answer += this.hammingWeight(this.words[k]);
   }
@@ -342,8 +347,8 @@ FastBitSet.prototype.difference_size = function (otherbitmap) {
 // Computes the changed elements (XOR) between this bitset and another one,
 // the current bitset is modified (and returned by the function)
 FastBitSet.prototype.change = function (otherbitmap) {
-  var mincount = Math.min(this.words.length, otherbitmap.words.length);
-  var k = 0 | 0;
+  const mincount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0 | 0;
   for (; k + 7 < mincount; k += 8) {
     this.words[k] ^= otherbitmap.words[k];
     this.words[k + 1] ^= otherbitmap.words[k + 1];
@@ -360,7 +365,7 @@ FastBitSet.prototype.change = function (otherbitmap) {
   // remaining words are all part of change
   if (otherbitmap.words.length > this.words.length) {
     // this.words = this.words.concat(otherbitmap.words.slice(k));
-    var maxcount = otherbitmap.words.length;
+    const maxcount = otherbitmap.words.length;
     for (; k < maxcount; ++k) {
       this.words[k] = otherbitmap.words[k];
     }
@@ -380,15 +385,15 @@ FastBitSet.prototype.new_change = function (otherbitmap) {
 
 // Computes the number of changed elements between this bitset and another one
 FastBitSet.prototype.change_size = function (otherbitmap) {
-  var mincount = Math.min(this.words.length, otherbitmap.words.length);
-  var answer = 0 | 0;
-  var k = 0 | 0;
+  const mincount = Math.min(this.words.length, otherbitmap.words.length);
+  let answer = 0 | 0;
+  let k = 0 | 0;
   for (; k < mincount; ++k) {
     answer += this.hammingWeight(this.words[k] ^ otherbitmap.words[k]);
   }
-  var longer =
+  const longer =
     this.words.length > otherbitmap.words.length ? this : otherbitmap;
-  var c = longer.words.length;
+  const c = longer.words.length;
   for (; k < c; ++k) {
     answer += this.hammingWeight(longer.words[k]);
   }
@@ -403,8 +408,8 @@ FastBitSet.prototype.toString = function () {
 // Computes the union between this bitset and another one,
 // the current bitset is modified  (and returned by the function)
 FastBitSet.prototype.union = function (otherbitmap) {
-  var mcount = Math.min(this.words.length, otherbitmap.words.length);
-  var k = 0 | 0;
+  const mcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0 | 0;
   for (; k + 7 < mcount; k += 8) {
     this.words[k] |= otherbitmap.words[k];
     this.words[k + 1] |= otherbitmap.words[k + 1];
@@ -420,8 +425,8 @@ FastBitSet.prototype.union = function (otherbitmap) {
   }
   if (this.words.length < otherbitmap.words.length) {
     this.resize((otherbitmap.words.length << 5) - 1);
-    var c = otherbitmap.words.length;
-    for (var k = mcount; k < c; ++k) {
+    const c = otherbitmap.words.length;
+    for (let k = mcount; k < c; ++k) {
       this.words[k] = otherbitmap.words[k];
     }
   }
@@ -429,11 +434,11 @@ FastBitSet.prototype.union = function (otherbitmap) {
 };
 
 FastBitSet.prototype.new_union = function (otherbitmap) {
-  var answer = Object.create(FastBitSet.prototype);
-  var count = Math.max(this.words.length, otherbitmap.words.length);
+  const answer = Object.create(FastBitSet.prototype);
+  const count = Math.max(this.words.length, otherbitmap.words.length);
   answer.words = new Array(count);
-  var mcount = Math.min(this.words.length, otherbitmap.words.length);
-  var k = 0;
+  const mcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0;
   for (; k + 7 < mcount; k += 8) {
     answer.words[k] = this.words[k] | otherbitmap.words[k];
     answer.words[k + 1] = this.words[k + 1] | otherbitmap.words[k + 1];
@@ -447,12 +452,12 @@ FastBitSet.prototype.new_union = function (otherbitmap) {
   for (; k < mcount; ++k) {
     answer.words[k] = this.words[k] | otherbitmap.words[k];
   }
-  var c = this.words.length;
-  for (var k = mcount; k < c; ++k) {
+  const c = this.words.length;
+  for (k = mcount; k < c; ++k) {
     answer.words[k] = this.words[k];
   }
-  var c2 = otherbitmap.words.length;
-  for (var k = mcount; k < c2; ++k) {
+  const c2 = otherbitmap.words.length;
+  for (k = mcount; k < c2; ++k) {
     answer.words[k] = otherbitmap.words[k];
   }
   return answer;
@@ -460,19 +465,19 @@ FastBitSet.prototype.new_union = function (otherbitmap) {
 
 // Computes the size union between this bitset and another one
 FastBitSet.prototype.union_size = function (otherbitmap) {
-  var mcount = Math.min(this.words.length, otherbitmap.words.length);
-  var answer = 0 | 0;
-  for (var k = 0 | 0; k < mcount; ++k) {
+  const mcount = Math.min(this.words.length, otherbitmap.words.length);
+  let answer = 0 | 0;
+  for (let k = 0 | 0; k < mcount; ++k) {
     answer += this.hammingWeight(this.words[k] | otherbitmap.words[k]);
   }
   if (this.words.length < otherbitmap.words.length) {
-    var c = otherbitmap.words.length;
-    for (var k = this.words.length; k < c; ++k) {
+    const c = otherbitmap.words.length;
+    for (let k = this.words.length; k < c; ++k) {
       answer += this.hammingWeight(otherbitmap.words[k] | 0);
     }
   } else {
-    var c = this.words.length;
-    for (var k = otherbitmap.words.length; k < c; ++k) {
+    const c = this.words.length;
+    for (let k = otherbitmap.words.length; k < c; ++k) {
       answer += this.hammingWeight(this.words[k] | 0);
     }
   }

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -324,6 +324,27 @@ FastBitSet.prototype.difference = function (otherbitmap) {
 };
 
 // Computes the difference between this bitset and another one,
+// the current bitset is modified (and returned by the function)
+FastBitSet.prototype.difference2 = function (otherbitmap) {
+  const newcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0 | 0;
+  for (; k + 7 < newcount; k += 8) {
+    otherbitmap.words[k] = this.words[k] & ~otherbitmap.words[k];
+    otherbitmap.words[k + 1] = this.words[k + 1] & ~otherbitmap.words[k + 1];
+    otherbitmap.words[k + 2] = this.words[k + 2] & ~otherbitmap.words[k + 2];
+    otherbitmap.words[k + 3] = this.words[k + 3] & ~otherbitmap.words[k + 3];
+    otherbitmap.words[k + 4] = this.words[k + 4] & ~otherbitmap.words[k + 4];
+    otherbitmap.words[k + 5] = this.words[k + 5] & ~otherbitmap.words[k + 5];
+    otherbitmap.words[k + 6] = this.words[k + 6] & ~otherbitmap.words[k + 6];
+    otherbitmap.words[k + 7] = this.words[k + 7] & ~otherbitmap.words[k + 7];
+  }
+  for (; k < newcount; ++k) {
+    otherbitmap.words[k] = this.words[k] & ~otherbitmap.words[k];
+  }
+  return otherbitmap;
+};
+
+// Computes the difference between this bitset and another one,
 // a new bitmap is generated
 FastBitSet.prototype.new_difference = function (otherbitmap) {
   return this.clone().difference(otherbitmap); // should be fast enough

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -389,12 +389,8 @@ FastBitSet.prototype.change = function (otherbitmap) {
     this.words[k] ^= otherbitmap.words[k];
   }
   // remaining words are all part of change
-  if (otherbitmap.words.length > this.words.length) {
-    // this.words = this.words.concat(otherbitmap.words.slice(k));
-    const maxcount = otherbitmap.words.length;
-    for (; k < maxcount; ++k) {
-      this.words[k] = otherbitmap.words[k];
-    }
+  for (k = otherbitmap.words.length - 1; k >= mincount; --k) {
+    this.words[k] = otherbitmap.words[k];
   }
   return this;
 };
@@ -402,11 +398,34 @@ FastBitSet.prototype.change = function (otherbitmap) {
 // Computes the change between this bitset and another one,
 // a new bitmap is generated
 FastBitSet.prototype.new_change = function (otherbitmap) {
-  if (otherbitmap.words.length > this.words.length) {
-    return this.clone().change(otherbitmap);
-  } else {
-    return otherbitmap.clone().change(this);
+  const answer = Object.create(FastBitSet.prototype);
+  const count = Math.max(this.words.length, otherbitmap.words.length);
+  answer.words = new Array(count);
+  const mcount = Math.min(this.words.length, otherbitmap.words.length);
+  let k = 0;
+  for (; k + 7 < mcount; k += 8) {
+    answer.words[k] = this.words[k] ^ otherbitmap.words[k];
+    answer.words[k + 1] = this.words[k + 1] ^ otherbitmap.words[k + 1];
+    answer.words[k + 2] = this.words[k + 2] ^ otherbitmap.words[k + 2];
+    answer.words[k + 3] = this.words[k + 3] ^ otherbitmap.words[k + 3];
+    answer.words[k + 4] = this.words[k + 4] ^ otherbitmap.words[k + 4];
+    answer.words[k + 5] = this.words[k + 5] ^ otherbitmap.words[k + 5];
+    answer.words[k + 6] = this.words[k + 6] ^ otherbitmap.words[k + 6];
+    answer.words[k + 7] = this.words[k + 7] ^ otherbitmap.words[k + 7];
   }
+  for (; k < mcount; ++k) {
+    answer.words[k] = this.words[k] ^ otherbitmap.words[k];
+  }
+
+  const c = this.words.length;
+  for (k = mcount; k < c; ++k) {
+    answer.words[k] = this.words[k];
+  }
+  const c2 = otherbitmap.words.length;
+  for (k = mcount; k < c2; ++k) {
+    answer.words[k] = otherbitmap.words[k];
+  }
+  return answer;
 };
 
 // Computes the number of changed elements between this bitset and another one

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ console.log(""+b);// should display {1,2}
 b.add(10);
 b.array(); // would return [1,2,10]
 var c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
-c.difference(b); // from c, remove elements that are in b
+c.difference(b); // from c, remove elements that are in b (modifies c)
+c.difference2(b) // from c, remove elements that are in b (modifies b)
 c.change(b); // c will contain all elements that are in b or in c, but not both (elements that changed)
 var su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
 c.union(b); // c will contain all elements that are in c and b

--- a/benchmark/test.js
+++ b/benchmark/test.js
@@ -1,30 +1,30 @@
 /* performance benchmark */
 /* This script expects node.js */
 
-'use strict';
+"use strict";
 
-var FastBitSet = require('../FastBitSet.js');
-var TypedFastBitSet = require('typedfastbitset');
-var BitSet = require('bitset.js');
-var Benchmark = require('benchmark');
-var tBitSet = require('bitset');
-var fBitSet = require('fast-bitset');
-var roaring = require('roaring');
-var os = require('os');
+const FastBitSet = require("../FastBitSet.js");
+const TypedFastBitSet = require("typedfastbitset");
+const BitSet = require("bitset.js");
+const Benchmark = require("benchmark");
+const tBitSet = require("bitset");
+const fBitSet = require("fast-bitset");
+const roaring = require("roaring");
+const os = require("os");
 
-var smallgap = 3
-var largegap = 210
+const smallgap = 3;
+const largegap = 210;
 
-var genericSetIntersection = function(set1, set2) {
-  var answer = new Set();
+const genericSetIntersection = function (set1, set2) {
+  const answer = new Set();
   if (set2.length > set1.length) {
-    for (var j of set1) {
+    for (const j of set1) {
       if (set2.has(j)) {
         answer.add(j);
       }
     }
   } else {
-    for (var j of set2) {
+    for (const j of set2) {
       if (set1.has(j)) {
         answer.add(j);
       }
@@ -33,8 +33,8 @@ var genericSetIntersection = function(set1, set2) {
   return answer;
 };
 
-var genericInplaceSetIntersection = function(set1, set2) {
-  for (var j of set2) {
+const genericInplaceSetIntersection = function (set1, set2) {
+  for (const j of set2) {
     if (!set1.has(j)) {
       set1.delete(j);
     }
@@ -42,394 +42,406 @@ var genericInplaceSetIntersection = function(set1, set2) {
   return set1;
 };
 
-var genericSetIntersectionCard = function(set1, set2) {
-  var answer = 0;
+const genericSetIntersectionCard = function (set1, set2) {
+  let answer = 0;
   if (set2.length > set1.length) {
-    for (var j of set1) {
+    for (const j of set1) {
       if (set2.has(j)) {
-        answer ++;
+        answer++;
       }
     }
   } else {
-    for (var j of set2.values()) {
+    for (const j of set2.values()) {
       if (set1.has(j)) {
-        answer ++;
+        answer++;
       }
     }
   }
   return answer;
 };
 
-var genericSetUnion = function(set1, set2) {
-  var answer = new Set(set1);
-  for (var j of set2) {
+const genericSetUnion = function (set1, set2) {
+  const answer = new Set(set1);
+  for (const j of set2) {
     answer.add(j);
   }
   return answer;
 };
 
-var genericInplaceSetUnion = function(set1, set2) {
-  for (var j of set2) {
+const genericInplaceSetUnion = function (set1, set2) {
+  for (const j of set2) {
     set1.add(j);
   }
   return set1;
 };
-var genericSetUnionCard = function(set1, set2) {
-  return set1.size + set2.size - genericSetIntersectionCard(set1,set2);
+
+const genericSetUnionCard = function (set1, set2) {
+  return set1.size + set2.size - genericSetIntersectionCard(set1, set2);
 };
 
-var genericSetDifference = function(set1, set2) {
-  var answer = new Set(set1);
-  for (var j of set2) {
+const genericSetDifference = function (set1, set2) {
+  const answer = new Set(set1);
+  for (const j of set2) {
     answer.delete(j);
   }
   return answer;
 };
 
-var genericInplaceSetDifference = function(set1, set2) {
-  for (var j of set2) {
+const genericInplaceSetDifference = function (set1, set2) {
+  for (const j of set2) {
     set1.delete(j);
   }
   return set1;
 };
 
-var genericSetDifferenceCard = function(set1, set2) {
-  return set1.size - genericSetIntersectionCard(set1,set2);
+const genericSetDifferenceCard = function (set1, set2) {
+  return set1.size - genericSetIntersectionCard(set1, set2);
 };
 
 const N = 1024 * 1024;
 
 function CreateBench() {
-  console.log('starting dynamic bitmap creation benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
+  console.log("starting dynamic bitmap creation benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
 
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N + 5);
-  for (var i = 0 ; i < N  ; i++) {
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
   }
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    var b = new FastBitSet();
-    for (var i = 0 ; i < N  ; i++) {
-      b.add(smallgap * i + 5);
-    }
-    return b;
-  })
-  .add('TypedFastBitSet', function() {
-    var b = new TypedFastBitSet();
-    for (var i = 0 ; i < N  ; i++) {
-      b.add(smallgap * i + 5);
-    }
-    return b;
-  })
-    .add('infusion.BitSet.js', function() {
-      var bs = new BitSet();
-      for (var i = 0 ; i < N  ; i++) {
-        bs = bs.set(smallgap * i + 5,true);
+  const ms = suite
+    .add("FastBitSet", function () {
+      const b = new FastBitSet();
+      for (let i = 0; i < N; i++) {
+        b.add(smallgap * i + 5);
+      }
+      return b;
+    })
+    .add("TypedFastBitSet", function () {
+      const b = new TypedFastBitSet();
+      for (let i = 0; i < N; i++) {
+        b.add(smallgap * i + 5);
+      }
+      return b;
+    })
+    .add("infusion.BitSet.js", function () {
+      let bs = new BitSet();
+      for (let i = 0; i < N; i++) {
+        bs = bs.set(smallgap * i + 5, true);
       }
       return bs;
     })
-    .add('tdegrunt.BitSet', function() {
-      var bt = new tBitSet();
-      for (var i = 0 ; i < N  ; i++) {
+    .add("tdegrunt.BitSet", function () {
+      const bt = new tBitSet();
+      for (let i = 0; i < N; i++) {
         bt.set(smallgap * i + 5);
       }
       return bt;
     })
-    .add('Set', function() {
-      var bt = new Set();
-      for (var i = 0 ; i < N  ; i++) {
+    .add("Set", function () {
+      const bt = new Set();
+      for (let i = 0; i < N; i++) {
         bt.add(smallgap * i + 5);
       }
       return bt;
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function ArrayBench() {
-  console.log('starting array extraction benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N + 5);
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting array extraction benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
     tb.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
   }
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    return b.array();
-  })
-  .add('TypedFastBitSet', function() {
-    return tb.array();
-  })
-    .add('infusion.BitSet.js', function() {
-      return bs.toArray();
+  const ms = suite
+    .add("FastBitSet", function () {
+      return b.array();
     })
-     .add('mattkrick.fast-bitset', function() {
+    .add("TypedFastBitSet", function () {
+      return tb.array();
+    })
+    // .add("infusion.BitSet.js", function () {
+    // return bs.toArray();
+    // })
+    .add("mattkrick.fast-bitset", function () {
       return fb.getIndices();
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function ForEachBench() {
-  console.log('starting forEach benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
+  console.log("starting forEach benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
 
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N + 5);
-  var s = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  const s = new Set();
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
     tb.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
     s.add(smallgap * i + 5);
   }
-  var card = 0;
-  for (var i in b.array()) {
+  let card = 0;
+  for (const i in b.array()) {
     card++;
   }
 
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    var card = 0;
-    var inc = function() {
-      card++;
-    };
-    b.forEach(inc);
-    return card;
-  }).add('TypedFastBitSet', function() {
-    var card = 0;
-    var inc = function() {
-      card++;
-    };
-    tb.forEach(inc);
-    return card;
-  }).add('FastBitSet (via array)', function() {
-    var card = 0;
-    for (var i in b.array()) {
-      card++;
-    }
-    return card;
-  })
-  .add('TypedFastBitSet (via array)', function() {
-    var card = 0;
-    for (var i in tb.array()) {
-      card++;
-    }
-    return card;
-  })
-    .add('mattkrick.fast-bitset', function() {
-      var card = 0;
-      var inc = function() {
+  const ms = suite
+    .add("FastBitSet", function () {
+      let card = 0;
+      const inc = function () {
+        card++;
+      };
+      b.forEach(inc);
+      return card;
+    })
+    .add("TypedFastBitSet", function () {
+      let card = 0;
+      const inc = function () {
+        card++;
+      };
+      tb.forEach(inc);
+      return card;
+    })
+    .add("FastBitSet (via array)", function () {
+      const card = 0;
+      for (const i in b.array()) {
+        card++;
+      }
+      return card;
+    })
+    .add("TypedFastBitSet (via array)", function () {
+      let card = 0;
+      for (const i in tb.array()) {
+        card++;
+      }
+      return card;
+    })
+    .add("mattkrick.fast-bitset", function () {
+      let card = 0;
+      const inc = function () {
         card++;
       };
       fb.forEach(inc);
       return card;
     })
-    .add('Set', function() {
-      var card = 0;
-      var inc = function() {
+    .add("Set", function () {
+      let card = 0;
+      const inc = function () {
         card++;
       };
       fb.forEach(inc);
       return card;
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function CardBench() {
-  console.log('starting cardinality benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N + 5);
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting cardinality benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
     tb.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
   }
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    return b.size();
-  }).add('TypedFastBitSet', function() {
-    return b.size();
-  })
-    .add('infusion.BitSet.js', function() {
+  const ms = suite
+    .add("FastBitSet", function () {
+      return b.size();
+    })
+    .add("TypedFastBitSet", function () {
+      return b.size();
+    })
+    .add("infusion.BitSet.js", function () {
       return bs.cardinality();
     })
-    .add('tdegrunt.BitSet', function() {
+    .add("tdegrunt.BitSet", function () {
       return bt.cardinality();
     })
-    .add('mattkrick.fast-bitset', function() {
+    .add("mattkrick.fast-bitset", function () {
       return fb.getCardinality();
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function QueryBench() {
-  console.log('starting query benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N + 5);
-  var s = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting query benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  const s = new Set();
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
     tb.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
     s.add(smallgap * i + 5);
   }
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    return b.has(122);
-  })
-  .add('TypedFastBitSet', function() {
-    return tb.has(122);
-  })
-    .add('infusion.BitSet.js', function() {
+  const ms = suite
+    .add("FastBitSet", function () {
+      return b.has(122);
+    })
+    .add("TypedFastBitSet", function () {
+      return tb.has(122);
+    })
+    .add("infusion.BitSet.js", function () {
       return bs.get(122);
     })
-    .add('tdegrunt.BitSet', function() {
+    .add("tdegrunt.BitSet", function () {
       return bt.get(122);
     })
-    .add('mattkrick.fast-bitset', function() {
+    .add("mattkrick.fast-bitset", function () {
       return fb.get(122);
     })
-    .add('Set', function() {
+    .add("Set", function () {
       return s.has(122);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function CloneBench() {
-  console.log('starting clone benchmark');
-  var b = new FastBitSet();
-  var tb = new TypedFastBitSet();
-  var bs = new BitSet();
-  var bt = new tBitSet();
-  var fb = new fBitSet(smallgap * N  + 5);
-  var s = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting clone benchmark");
+  const b = new FastBitSet();
+  const tb = new TypedFastBitSet();
+  let bs = new BitSet();
+  const bt = new tBitSet();
+  const fb = new fBitSet(smallgap * N + 5);
+  const s = new Set();
+  for (let i = 0; i < N; i++) {
     b.add(smallgap * i + 5);
     tb.add(smallgap * i + 5);
-    bs = bs.set(smallgap * i + 5,true);
+    bs = bs.set(smallgap * i + 5, true);
     bt.set(smallgap * i + 5);
     fb.set(smallgap * i + 5);
     s.add(smallgap * i + 5);
   }
-  if (bs.cardinality() != b.size()) throw 'something is off';
-  if (bs.cardinality() != bt.cardinality()) throw 'something is off';
-  if (bs.cardinality() != fb.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs.cardinality() != b.size()) throw "something is off";
+  if (bs.cardinality() != bt.cardinality()) throw "something is off";
+  if (bs.cardinality() != fb.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet', function() {
-    return b.clone();
-  }).add('TypedFastBitSet', function() {
-    return tb.clone();
-  })
-    .add('infusion.BitSet.js', function() {
+  const ms = suite
+    .add("FastBitSet", function () {
+      return b.clone();
+    })
+    .add("TypedFastBitSet", function () {
+      return tb.clone();
+    })
+    .add("infusion.BitSet.js", function () {
       return bs.clone();
     })
-    .add('mattkrick.fast-bitset', function() {
+    .add("mattkrick.fast-bitset", function () {
       return fb.clone();
     })
-    .add('Set', function() {
+    .add("Set", function () {
       return new Set(s);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function AndBench() {
-  console.log('starting intersection query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting intersection query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  let bs1 = new BitSet();
+  let bs2 = new BitSet();
+
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -437,64 +449,66 @@ function AndBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
 
-  var suite = new Benchmark.Suite();
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (creates new bitset)', function() {
-    return b1.new_intersection(b2);
-  })
-  .add('TypedFastBitSet (creates new bitset)', function() {
-    return tb1.new_intersection(tb2);
-  })
-    .add('mattkrick.fast-bitset  (creates new bitset)', function() {
+  const ms = suite
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.new_intersection(b2);
+    })
+    .add("TypedFastBitSet (creates new bitset)", function () {
+      return tb1.new_intersection(tb2);
+    })
+    .add("mattkrick.fast-bitset  (creates new bitset)", function () {
       return fb1.and(fb2);
     })
 
-    .add('roaring', function() {
-      return roaring.RoaringBitmap32.and(r1,r2);
+    .add("roaring", function () {
+      return roaring.RoaringBitmap32.and(r1, r2);
     })
-    .add('Set', function() {
-      return genericSetIntersection(s1,s2);
+    .add("Set", function () {
+      return genericSetIntersection(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function AndCardBench() {
-  console.log('starting intersection cardinality query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting intersection cardinality query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  let bs1 = new BitSet();
+  let bs2 = new BitSet();
+
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -502,70 +516,72 @@ function AndCardBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (genericSetIntersectionCard(s1,s2) != b1.intersection_size(b2)) throw 'potential bug';
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (genericSetIntersectionCard(s1, s2) != b1.intersection_size(b2))
+    throw "potential bug";
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
 
-  var suite = new Benchmark.Suite();
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (creates new bitset)', function() {
-    return b1.new_intersection(b2).size();
-  })
-    .add('FastBitSet (fast way)', function() {
+  const ms = suite
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.new_intersection(b2).size();
+    })
+    .add("FastBitSet (fast way)", function () {
       return b1.intersection_size(b2);
     })
-    .add('TypedFastBitSet (creates new bitset)', function() {
+    .add("TypedFastBitSet (creates new bitset)", function () {
       return tb1.new_intersection(tb2).size();
     })
-      .add('TypedFastBitSet (fast way)', function() {
-        return tb1.intersection_size(tb2);
-      })
-        .add('roaring', function() {
-          return r1.andCardinality(r2);
-        })
-    .add('mattkrick.fast-bitset (creates new bitset)', function() {
+    .add("TypedFastBitSet (fast way)", function () {
+      return tb1.intersection_size(tb2);
+    })
+    .add("roaring", function () {
+      return r1.andCardinality(r2);
+    })
+    .add("mattkrick.fast-bitset (creates new bitset)", function () {
       return fb1.and(fb2).getCardinality();
     })
-    .add('Set', function() {
-      return genericSetIntersectionCard(s1,s2);
+    .add("Set", function () {
+      return genericSetIntersectionCard(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function OrCardBench() {
-  console.log('starting union cardinality query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting union cardinality query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  let bs1 = new BitSet();
+  let bs2 = new BitSet();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -573,69 +589,70 @@ function OrCardBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
 
-  var suite = new Benchmark.Suite();
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (creates new bitset)', function() {
-    return b1.new_union(b2).size();
-  })
-    .add('FastBitSet (fast way)', function() {
+  const ms = suite
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.new_union(b2).size();
+    })
+    .add("FastBitSet (fast way)", function () {
       return b1.union_size(b2);
     })
-    .add('TypedFastBitSet (creates new bitset)', function() {
+    .add("TypedFastBitSet (creates new bitset)", function () {
       return tb1.new_union(tb2).size();
     })
-      .add('TypedFastBitSet (fast way)', function() {
-        return tb1.union_size(tb2);
-      })
-        .add('roaring', function() {
-          return r1.orCardinality(r2);
-        })
-    .add('mattkrick.fast-bitset (creates new bitset)', function() {
+    .add("TypedFastBitSet (fast way)", function () {
+      return tb1.union_size(tb2);
+    })
+    .add("roaring", function () {
+      return r1.orCardinality(r2);
+    })
+    .add("mattkrick.fast-bitset (creates new bitset)", function () {
       return fb1.or(fb2).getCardinality();
     })
-    .add('Set', function() {
-      return genericSetUnionCard(s1,s2);
+    .add("Set", function () {
+      return genericSetUnionCard(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function DifferenceCardBench() {
-  console.log('starting difference cardinality query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting difference cardinality query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  let bs1 = new BitSet();
+  let bs2 = new BitSet();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -643,66 +660,67 @@ function DifferenceCardBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
 
-  var suite = new Benchmark.Suite();
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (creates new bitset)', function() {
-    return b1.new_union(b2).size();
-  })
-    .add('FastBitSet (fast way)', function() {
+  const ms = suite
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.new_union(b2).size();
+    })
+    .add("FastBitSet (fast way)", function () {
       return b1.difference_size(b2);
     })
-    .add('TypedFastBitSet (creates new bitset)', function() {
+    .add("TypedFastBitSet (creates new bitset)", function () {
       return tb1.new_union(tb2).size();
     })
-      .add('TypedFastBitSet (fast way)', function() {
-        return tb1.difference_size(tb2);
-      })
-        .add('roaring', function() {
-          return r1.andNotCardinality(r2);
-        })
-    .add('Set', function() {
-      return genericSetDifferenceCard(s1,s2);
+    .add("TypedFastBitSet (fast way)", function () {
+      return tb1.difference_size(tb2);
+    })
+    .add("roaring", function () {
+      return r1.andNotCardinality(r2);
+    })
+    .add("Set", function () {
+      return genericSetDifferenceCard(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function OrInplaceBench() {
-  console.log('starting inplace union  benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting inplace union  benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  let bs1 = new BitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  let bs2 = new BitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -710,66 +728,67 @@ function OrInplaceBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
 
-  var suite = new Benchmark.Suite();
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (inplace)', function() {
-    return b1.union(b2);
-  })
-  .add('TypedFastBitSet (inplace)', function() {
-    return tb1.union(tb2);
-  })
-    .add('infusion.BitSet.js (inplace)', function() {
+  const ms = suite
+    .add("FastBitSet (inplace)", function () {
+      return b1.union(b2);
+    })
+    .add("TypedFastBitSet (inplace)", function () {
+      return tb1.union(tb2);
+    })
+    .add("infusion.BitSet.js (inplace)", function () {
       return bs1.or(bs2);
     })
-     .add('tdegrunt.BitSet (inplace)', function() {
+    .add("tdegrunt.BitSet (inplace)", function () {
       return bt1.or(bt2);
     })
-    .add('roaring', function() {
-          return r1.orInPlace(r2);
+    .add("roaring", function () {
+      return r1.orInPlace(r2);
     })
-    .add('Set (inplace)', function() {
-      return genericInplaceSetUnion(s1,s2);
+    .add("Set (inplace)", function () {
+      return genericInplaceSetUnion(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function AndInplaceBench() {
-  console.log('starting inplace intersection  benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting inplace intersection  benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  let bs1 = new BitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  let bs2 = new BitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -777,137 +796,150 @@ function AndInplaceBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
   b1.intersection(b2);
   bt1.and(bt2);
-  genericInplaceSetIntersection(s1,s2);
-  var suite = new Benchmark.Suite();
+  genericInplaceSetIntersection(s1, s2);
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (inplace)', function() {
-    return b1.intersection(b2);
-  })
-  .add('TypedFastBitSet (inplace)', function() {
-    return tb1.intersection(tb2);
-  })
-    .add('infusion.BitSet.js (inplace)', function() {
+  const ms = suite
+    .add("FastBitSet (inplace)", function () {
+      return b1.intersection(b2);
+    })
+    .add("TypedFastBitSet (inplace)", function () {
+      return tb1.intersection(tb2);
+    })
+    .add("infusion.BitSet.js (inplace)", function () {
       return bs1.and(bs2);
     })
-     .add('tdegrunt.BitSet (inplace)', function() {
+    .add("tdegrunt.BitSet (inplace)", function () {
       return bt1.and(bt2);
     })
-    .add('roaring', function() {
-          return r1.andInPlace(r2);
+    .add("roaring", function () {
+      return r1.andInPlace(r2);
     })
-    .add('Set (inplace)', function() {
-      return genericInplaceSetIntersection(s1,s2);
+    .add("Set (inplace)", function () {
+      return genericInplaceSetIntersection(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function AndNotInplaceBench() {
-  console.log('starting inplace difference  benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting inplace difference  benchmark");
+  const b1 = new FastBitSet();
+  const bb1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  let bs1 = new BitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const bb2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  let bs2 = new BitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
+    bb1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
     r1.add(smallgap * i + 5);
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
+    bb2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bb1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bb2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
+
   b1.difference(b2);
+  bb1.difference2(bb2);
   bt1.andNot(bt2);
-  genericInplaceSetDifference(s1,s2);
-  var suite = new Benchmark.Suite();
+  genericInplaceSetDifference(s1, s2);
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (inplace)', function() {
-    return b1.difference(b2);
-  })
-  .add('TypedFastBitSet (inplace)', function() {
-    return tb1.difference(tb2);
-  })
-    .add('infusion.BitSet.js (inplace)', function() {
+  const ms = suite
+    .add("FastBitSet (inplace)", function () {
+      return b1.difference(b2);
+    })
+    .add("FastBitSet (inplace2)", function () {
+      return bb1.difference(bb2);
+    })
+    .add("TypedFastBitSet (inplace)", function () {
+      return tb1.difference(tb2);
+    })
+    .add("infusion.BitSet.js (inplace)", function () {
       return bs1.andNot(bs2);
     })
-    .add('tdegrunt.BitSet (inplace)', function() {
+    .add("tdegrunt.BitSet (inplace)", function () {
       return bt1.andNot(bt2);
     })
-        .add('roaring', function() {
-          return r1.andNotInPlace(r2);
-        })
-    .add('Set (inplace)', function() {
-      return genericInplaceSetDifference(s1,s2);
+    .add("roaring", function () {
+      return r1.andNotInPlace(r2);
+    })
+    .add("Set (inplace)", function () {
+      return genericInplaceSetDifference(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function OrBench() {
-  console.log('starting union query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting union query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  let bs1 = new BitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  let bs2 = new BitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -915,64 +947,64 @@ function OrBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
-  roaring.RoaringBitmap32.or(r1,r2);
-  var suite = new Benchmark.Suite();
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
+  roaring.RoaringBitmap32.or(r1, r2);
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite
-    .add('roaring', function() {
-      return roaring.RoaringBitmap32.or(r1,r2);
+  const ms = suite
+    .add("roaring", function () {
+      return roaring.RoaringBitmap32.or(r1, r2);
     })
-   .add('FastBitSet (creates new bitset)', function() {
-     return b1.new_union(b2);
-   })
-   .add('TypedFastBitSet (creates new bitset)', function() {
-    return tb1.new_union(tb2);
-  })
-   .add('mattkrick.fast-bitset (creates new bitset)', function() {
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.new_union(b2);
+    })
+    .add("TypedFastBitSet (creates new bitset)", function () {
+      return tb1.new_union(tb2);
+    })
+    .add("mattkrick.fast-bitset (creates new bitset)", function () {
       return fb1.or(fb2);
-   })
-   .add('Set', function() {
-      return genericSetUnion(s1,s2);
+    })
+    .add("Set", function () {
+      return genericSetUnion(s1, s2);
     })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
 function DifferenceBench() {
-  console.log('starting difference query benchmark');
-  var b1 = new FastBitSet();
-  var tb1 = new TypedFastBitSet();
-  var bs1 = new BitSet();
-  var bt1 = new tBitSet();
-  var r1 = new roaring.RoaringBitmap32();
-  var r2 = new roaring.RoaringBitmap32();
-  var fb1 = new fBitSet(largegap * N + 5);
-  var b2 = new FastBitSet();
-  var tb2 = new TypedFastBitSet();
-  var bs2 = new BitSet();
-  var bt2 = new tBitSet();
-  var fb2 = new fBitSet(largegap * N + 5);
-  var s1 = new Set();
-  var s2 = new Set();
-  for (var i = 0 ; i < N  ; i++) {
+  console.log("starting difference query benchmark");
+  const b1 = new FastBitSet();
+  const tb1 = new TypedFastBitSet();
+  let bs1 = new BitSet();
+  const bt1 = new tBitSet();
+  const r1 = new roaring.RoaringBitmap32();
+  const r2 = new roaring.RoaringBitmap32();
+  const fb1 = new fBitSet(largegap * N + 5);
+  const b2 = new FastBitSet();
+  const tb2 = new TypedFastBitSet();
+  let bs2 = new BitSet();
+  const bt2 = new tBitSet();
+  const fb2 = new fBitSet(largegap * N + 5);
+  const s1 = new Set();
+  const s2 = new Set();
+  for (let i = 0; i < N; i++) {
     b1.add(smallgap * i + 5);
     tb1.add(smallgap * i + 5);
-    bs1 = bs1.set(smallgap * i + 5,true);
+    bs1 = bs1.set(smallgap * i + 5, true);
     bt1.set(smallgap * i + 5);
     fb1.set(smallgap * i + 5);
     s1.add(smallgap * i + 5);
@@ -980,91 +1012,114 @@ function DifferenceBench() {
     r2.add(largegap * i + 5);
     b2.add(largegap * i + 5);
     tb2.add(largegap * i + 5);
-    bs2 = bs2.set(largegap * i + 5,true);
+    bs2 = bs2.set(largegap * i + 5, true);
     bt2.set(largegap * i + 5);
     fb2.set(largegap * i + 5);
     s2.add(largegap * i + 5);
   }
-  if (bs1.cardinality() != b1.size()) throw 'something is off';
-  if (bs1.cardinality() != bt1.cardinality()) throw 'something is off';
-  if (bs1.cardinality() != fb1.getCardinality()) throw 'something is off';
-  if (bs2.cardinality() != b2.size()) throw 'something is off';
-  if (bs2.cardinality() != bt2.cardinality()) throw 'something is off';
-  if (bs2.cardinality() != fb2.getCardinality()) throw 'something is off';
-  var suite = new Benchmark.Suite();
+  if (bs1.cardinality() != b1.size()) throw "something is off";
+  if (bs1.cardinality() != bt1.cardinality()) throw "something is off";
+  if (bs1.cardinality() != fb1.getCardinality()) throw "something is off";
+  if (bs2.cardinality() != b2.size()) throw "something is off";
+  if (bs2.cardinality() != bt2.cardinality()) throw "something is off";
+  if (bs2.cardinality() != fb2.getCardinality()) throw "something is off";
+  const suite = new Benchmark.Suite();
   // add tests
-  var ms = suite.add('FastBitSet (creates new bitset)', function() {
-    return b1.clone().difference(b2);
-  })
-  .add('TypedFastBitSet (creates new bitset)', function() {
-    return tb1.clone().difference(tb2);
-  })
-    .add('Set', function() {
-      return genericSetDifference(s1,s2);
+  const ms = suite
+    .add("FastBitSet (creates new bitset)", function () {
+      return b1.clone().difference(b2);
+    })
+    .add("TypedFastBitSet (creates new bitset)", function () {
+      return tb1.clone().difference(tb2);
+    })
+    .add("Set", function () {
+      return genericSetDifference(s1, s2);
     })
     //.add('roaring', function() {
-   //       return roaring.RoaringBitmap32.andNot(r1,r2);
-   // })
+    //       return roaring.RoaringBitmap32.andNot(r1,r2);
+    // })
     // add listeners
-    .on('cycle', function(event) {
+    .on("cycle", function (event) {
       console.log(String(event.target));
     })
     // run async
-    .run({'async': false});
+    .run({ async: false });
 }
 
-var main = function() {
-  console.log('Benchmarking against:');
-  console.log('TypedFastBitSet.js: https://github.com/lemire/TypedFastBitSet.js');
-  console.log('roaring: https://www.npmjs.com/package/roaring');
-  console.log('infusion.BitSet.js from https://github.com/infusion/BitSet.js', require("bitset.js/package.json").version);
-  console.log('tdegrunt.BitSet from https://github.com/tdegrunt/bitset', require("bitset/package.json").version);
-  console.log('mattkrick.fast-bitset from https://github.com/mattkrick/fast-bitset', require("fast-bitset/package.json").version);
-  console.log('standard Set object from JavaScript');
-  console.log('');
-  console.log('Not all libraries support all operations. We benchmark what is available.');
-  console.log('');
-  console.log('Platform: ' + process.platform + ' ' + os.release() + ' ' + process.arch);
-  console.log(os.cpus()[0]['model']);
-  console.log('Node version ' + process.versions.node + ', v8 version ' + process.versions.v8);
+const main = function () {
+  console.log("Benchmarking against:");
+  console.log(
+    "TypedFastBitSet.js: https://github.com/lemire/TypedFastBitSet.js"
+  );
+  console.log("roaring: https://www.npmjs.com/package/roaring");
+  console.log(
+    "infusion.BitSet.js from https://github.com/infusion/BitSet.js",
+    require("bitset.js/package.json").version
+  );
+  console.log(
+    "tdegrunt.BitSet from https://github.com/tdegrunt/bitset",
+    require("bitset/package.json").version
+  );
+  console.log(
+    "mattkrick.fast-bitset from https://github.com/mattkrick/fast-bitset",
+    require("fast-bitset/package.json").version
+  );
+  console.log("standard Set object from JavaScript");
+  console.log("");
+  console.log(
+    "Not all libraries support all operations. We benchmark what is available."
+  );
+  console.log("");
+  console.log(
+    "Platform: " + process.platform + " " + os.release() + " " + process.arch
+  );
+  console.log(os.cpus()[0]["model"]);
+  console.log(
+    "Node version " +
+      process.versions.node +
+      ", v8 version " +
+      process.versions.v8
+  );
   console.log();
-  console.log('We proceed with the logical operations generating new bitmaps: ');
-  console.log('');
+  console.log(
+    "We proceed with the logical operations generating new bitmaps: "
+  );
+  console.log("");
   OrBench();
-  console.log('');
+  console.log("");
   AndBench();
-  console.log('');
+  console.log("");
   DifferenceBench();
-  console.log('');
-  console.log('We benchmark the in-place logical operations: ');
-  console.log('(Notice how much faster they are.)');
-  console.log('');
+  console.log("");
+  console.log("We benchmark the in-place logical operations: ");
+  console.log("(Notice how much faster they are.)");
+  console.log("");
   OrInplaceBench();
-  console.log('');
+  console.log("");
   AndInplaceBench();
-  console.log('');
+  console.log("");
   AndNotInplaceBench();
-  console.log('');
-  console.log('We benchmark the operations computing the set sizes: ');
-  console.log('');
+  console.log("");
+  console.log("We benchmark the operations computing the set sizes: ");
+  console.log("");
   CardBench();
-  console.log('');
+  console.log("");
   OrCardBench();
-  console.log('');
+  console.log("");
   AndCardBench();
-  console.log('');
+  console.log("");
   DifferenceCardBench();
-  console.log('');
-  console.log('We conclude with other benchmarks: ');
-  console.log('');
+  console.log("");
+  console.log("We conclude with other benchmarks: ");
+  console.log("");
   CreateBench();
-  console.log('');
+  console.log("");
   QueryBench();
-  console.log('');
+  console.log("");
   ArrayBench();
-  console.log('');
+  console.log("");
   ForEachBench();
-  console.log('');
+  console.log("");
   CloneBench();
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       "dev": true
     },
     "bitset": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/bitset/-/bitset-5.0.3.tgz",
-      "integrity": "sha512-sUf+oh2tLafEOCliDSAsCYYj8m9ebq22Efw74eaP2AwV1JdWktrtFOt73unr/YoThFOYYANJhBvD7UZyYtUBsA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bitset/-/bitset-5.1.1.tgz",
+      "integrity": "sha512-oKaRp6mzXedJ1Npo86PKhWfDelI6HxxJo+it9nAcBB0HLVvYVp+5i6yj6DT5hfFgo+TS5T57MRWtw8zhwdTs3g==",
       "dev": true
     },
     "bitset.js": {
@@ -605,6 +605,16 @@
         "chalk": "^4.0.0"
       }
     },
+    "microtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
+      "integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^1.2.0",
+        "node-gyp-build": "^3.8.0"
+      }
+    },
     "mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
@@ -698,6 +708,18 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "dev": true
     },
     "noop-logger": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   },
   "devDependencies": {
     "benchmark": "~1.0.0",
+    "bitset": "^5.1.1",
     "bitset.js": "^5.0.0",
     "fast-bitset": "^1.3.2",
+    "microtime": "^3.0.0",
     "mocha": "^8.2.1",
     "roaring": "^1.0.6",
     "typedfastbitset": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "main": "FastBitSet.js",
   "scripts": {
-    "test": "mocha unit/basictests.js"
+    "test": "mocha unit/basictests.js",
+    "benchmark": "nodejs benchmark/test.js"
   },
   "license": "Apache-2.0",
   "bugs": {

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -135,6 +135,19 @@ describe("BitSet", function () {
     if (mb2.size() != 2) throw "bad diff";
   });
 
+  it("Testing difference2", function () {
+    const a1 = [1, 2, 4, 5, 10];
+    const a2 = [1, 2, 4, 5, 10, 100, 1000];
+    let mb1 = new FastBitSet(a1);
+    let mb2 = new FastBitSet(a2);
+    mb1.difference2(mb2);
+    if (!mb2.isEmpty()) throw "bad diff1";
+    mb1 = new FastBitSet(a1);
+    mb2 = new FastBitSet(a2);
+    mb2.difference2(mb1);
+    if (mb1.size() != 2) throw "bad diff2";
+  });
+
   it("Testing union", function () {
     const a1 = [1, 2, 4, 5, 10];
     const a2 = [1, 2, 4, 5, 10, 100, 1000];

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -3,10 +3,10 @@
 "use strict";
 
 describe("BitSet", function () {
-  var FastBitSet = require("../FastBitSet.js");
+  const FastBitSet = require("../FastBitSet.js");
 
   function arraysEquals(a, b) {
-    var i = a.length;
+    let i = a.length;
     if (i != b.length) return false;
     while (i--) {
       if (a[i] !== b[i]) return false;
@@ -15,52 +15,52 @@ describe("BitSet", function () {
   }
 
   it("Testing set/get/clear", function () {
-    var mb = new FastBitSet();
-    var N = 1024;
-    for (var i = 0; i < N; i++) {
+    const mb = new FastBitSet();
+    const N = 1024;
+    for (let i = 0; i < N; i++) {
       mb.add(i);
       if (!mb.has(i)) throw "set did not register";
       if (mb.size() != i + 1) throw "cardinality bug " + i + " " + mb.size();
-      for (var j = 0; j <= i; j++) {
+      for (let j = 0; j <= i; j++) {
         if (!mb.has(j)) throw "bad get";
       }
-      for (var j = i + 1; j < N; j++) {
+      for (let j = i + 1; j < N; j++) {
         if (mb.has(j)) throw "bad get";
       }
     }
-    for (var i = N - 1; i >= 0; i--) {
+    for (let i = N - 1; i >= 0; i--) {
       mb.remove(i);
       if (mb.has(i)) throw "clear did not register";
       if (mb.size() != i) throw "cardinality bug " + i + " " + mb.size();
-      for (var j = 0; j < i; j++) {
+      for (let j = 0; j < i; j++) {
         if (!mb.has(j)) throw "bad get";
       }
-      for (var j = i; j < N; j++) {
+      for (let j = i; j < N; j++) {
         if (mb.has(j)) throw "bad get";
       }
     }
   });
 
   it("Testing init", function () {
-    var ai = [1, 2, 4, 5, 10];
-    var mb = new FastBitSet(ai);
+    const ai = [1, 2, 4, 5, 10];
+    const mb = new FastBitSet(ai);
     if (mb.size() != ai.length) throw "bad init";
   });
 
   it("Testing array", function () {
-    for (var i = 0; i < 128; i++) {
-      for (var j = 0; j < i; j++) {
-        var ai = [j, i];
-        var mb = new FastBitSet(ai);
+    for (let i = 0; i < 128; i++) {
+      for (let j = 0; j < i; j++) {
+        const ai = [j, i];
+        const mb = new FastBitSet(ai);
         if (!arraysEquals(ai, mb.array())) throw "bad array";
       }
     }
   });
 
   it("Testing card", function () {
-    for (var offset = 1; offset < 32; offset++) {
-      var mb = new FastBitSet();
-      for (var i = 0; i < 1024; i++) {
+    for (let offset = 1; offset < 32; offset++) {
+      const mb = new FastBitSet();
+      for (let i = 0; i < 1024; i++) {
         mb.add(i * offset);
         if (mb.size() != i + 1)
           throw "bad card " + i + " offset = " + offset + " " + mb.size();
@@ -69,65 +69,65 @@ describe("BitSet", function () {
   });
 
   it("Testing values", function () {
-    var ai = [1, 2, 4, 5, 10];
-    var mb = new FastBitSet(ai);
-    var a = mb.array();
+    const ai = [1, 2, 4, 5, 10];
+    const mb = new FastBitSet(ai);
+    const a = mb.array();
     if (!arraysEquals(a, ai)) throw "bad values";
-    for (var i = 0; i < a.length; i++) {
+    for (let i = 0; i < a.length; i++) {
       if (!mb.has(a[i])) throw "bad enumeration";
     }
   });
 
   it("Testing clone", function () {
-    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64];
-    var mb = new FastBitSet(ai);
-    var mb2 = mb.clone();
-    var a = mb2.array();
+    const ai = [1, 2, 4, 5, 10, 31, 32, 63, 64];
+    const mb = new FastBitSet(ai);
+    const mb2 = mb.clone();
+    const a = mb2.array();
     if (!arraysEquals(a, ai)) throw "bad values";
     if (!mb.equals(mb2)) throw "bad clone";
   });
 
   it("Testing trim", function () {
-    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
-    var mb = new FastBitSet(ai);
-    var mb2 = mb.clone();
+    const ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
+    const mb = new FastBitSet(ai);
+    const mb2 = mb.clone();
     mb2.trim();
-    var a = mb2.array();
+    const a = mb2.array();
     if (!arraysEquals(a, ai)) throw "bad values";
     if (!mb.equals(mb2)) throw "bad trim/clone";
   });
 
   it("Testing iterator", function () {
-    var ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
-    var mb = new FastBitSet(ai);
-    var arr = [];
-    for (var x of mb) arr.push(x);
+    const ai = [1, 2, 4, 5, 10, 31, 32, 63, 64, 127, 2030];
+    const mb = new FastBitSet(ai);
+    const arr = [];
+    for (const x of mb) arr.push(x);
     if (!arraysEquals(ai, arr)) throw "bad iterator";
-    var mb2 = new FastBitSet(mb);
+    const mb2 = new FastBitSet(mb);
     if (!mb.equals(mb2)) throw "bad iterator/init";
   });
 
   it("Testing intersection", function () {
-    var a1 = [1, 2, 4, 5, 10];
-    var a2 = [1, 2, 4, 5, 10, 100, 1000];
-    var mb1 = new FastBitSet(a1);
-    var mb2 = new FastBitSet(a2);
-    var pinter = mb1.intersection_size(mb2);
+    const a1 = [1, 2, 4, 5, 10];
+    const a2 = [1, 2, 4, 5, 10, 100, 1000];
+    const mb1 = new FastBitSet(a1);
+    const mb2 = new FastBitSet(a2);
+    let pinter = mb1.intersection_size(mb2);
     mb1.intersection(mb2);
     if (pinter != mb1.size()) throw "bad size";
-    var a = mb1.array();
+    const a = mb1.array();
     if (!arraysEquals(a, a1)) throw "bad values";
-    var pinter = mb2.intersection_size(mb1);
+    pinter = mb2.intersection_size(mb1);
     mb2.intersection(mb1);
     if (pinter != mb2.size()) throw "bad size";
     if (!mb1.equals(mb2)) throw "bad intersect";
   });
 
   it("Testing difference", function () {
-    var a1 = [1, 2, 4, 5, 10];
-    var a2 = [1, 2, 4, 5, 10, 100, 1000];
-    var mb1 = new FastBitSet(a1);
-    var mb2 = new FastBitSet(a2);
+    const a1 = [1, 2, 4, 5, 10];
+    const a2 = [1, 2, 4, 5, 10, 100, 1000];
+    let mb1 = new FastBitSet(a1);
+    const mb2 = new FastBitSet(a2);
     mb1.difference(mb2);
     if (!mb1.isEmpty()) throw "bad diff";
     mb1 = new FastBitSet(a1);
@@ -136,35 +136,35 @@ describe("BitSet", function () {
   });
 
   it("Testing union", function () {
-    var a1 = [1, 2, 4, 5, 10];
-    var a2 = [1, 2, 4, 5, 10, 100, 1000];
-    var mb1 = new FastBitSet(a1);
-    var mb2 = new FastBitSet(a2);
-    var punion = mb1.union_size(mb2);
+    const a1 = [1, 2, 4, 5, 10];
+    const a2 = [1, 2, 4, 5, 10, 100, 1000];
+    let mb1 = new FastBitSet(a1);
+    const mb2 = new FastBitSet(a2);
+    let punion = mb1.union_size(mb2);
     mb1.union(mb2);
     if (punion != mb1.size()) throw "bad size";
     if (!mb1.equals(mb2)) throw "bad diff";
     mb1 = new FastBitSet(a1);
-    var punion = mb2.union_size(mb1);
+    punion = mb2.union_size(mb1);
     mb2.union(mb1);
     if (punion != mb2.size()) throw "bad size";
-    var a = mb2.array();
+    const a = mb2.array();
     if (!arraysEquals(a, a2)) throw "bad values";
   });
 
   it("Testing change", function () {
-    var a1 = [1, 2, 4, 5, 10];
-    var a2 = [1, 2, 4, 5, 10, 100, 1000];
+    const a1 = [1, 2, 4, 5, 10];
+    const a2 = [1, 2, 4, 5, 10, 100, 1000];
     var ch = [100, 1000];
-    var mb1 = new FastBitSet(a1);
-    var mb2 = new FastBitSet(a2);
+    let mb1 = new FastBitSet(a1);
+    const mb2 = new FastBitSet(a2);
     if (mb1.change_size(mb2) !== mb2.change_size(mb1)) throw "bad change_size";
     if (!mb1.new_change(mb2).equals(mb2.new_change(mb1)))
       throw "bad new_change";
-    var arr = mb1.change(mb2).array();
+    let arr = mb1.change(mb2).array();
     if (!arraysEquals(arr, ch)) throw "bad change";
-    var mb1 = new FastBitSet(a1);
-    var arr = mb2.change(mb1).array();
+    mb1 = new FastBitSet(a1);
+    arr = mb2.change(mb1).array();
     if (!arraysEquals(arr, ch)) throw "bad change";
   });
 });


### PR DESCRIPTION
Hello again and happy new year.  In this pull request I have 

- Changed all `var` statements to the modern `let` and `const` where appropriate, in the module itself and the tests and benchmarks.

- Added a `FastBitSet.fromWords` constructor, for creating a new `FastBitSet` if we already have words.  Actually this is meant more for the TypedArray version, which I will make a pull request for soon.
  
- Added a (sort of) new method called `difference2`.  The difference method (AND NOT) is not commutative like the other operations, so the existing in-place operation may modify the wrong object for a potential use.  In my case, I am monitoring new changes from one moment to the next, so I want to modify the old `FastBitSet`, not the new one.  For `FastBitSet` objects `A` and `B`, `A.difference2(B)` performs the same operation as `A.difference(B)`, in-place, except it modifies `B` instead of `A`.  I made it into a new method instead of modifying the existing one because I did not want to affect performance of the original one, which is faster.  `difference2` is slower than `difference`, but it is still much faster than `new_difference`.
     
-  Added benchmarks for the `change` and `new_change` (XOR) methods that I introduced in my last pull request.

-  After running the benchmarks I discovered that `change` and especially `new_change` were too slow, so I made them both more efficient.

-  Added  all the required libraries for Benchmarking into `package.json` dev-dependencies, and a new `npm run benchmark` script, making it easy to run benchmarks.


Note: I disabled the `infusion.BitSet.js` benchmark for `ArrayBench()` because for some reason it was making my laptop hang.