### PR TITLE
update benchmarks

### DIFF
--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -118,7 +118,7 @@ FastBitSet.prototype.trim = function (index) {
   while (nl > 0 && this.words[nl - 1] === 0) {
     nl--;
   }
-  this.words = this.words.slice(0, nl);
+  this.words.length = nl;
 };
 
 // Resize the bitset so that we can write a value at index
@@ -327,6 +327,29 @@ FastBitSet.prototype.difference = function (otherbitmap) {
 };
 
 // Computes the difference between this bitset and another one,
+// a new bitmap is generated
+FastBitSet.prototype.new_difference = function (otherbitmap) {
+  const answer = Object.create(FastBitSet.prototype);
+  const count = Math.min(this.words.length, otherbitmap.words.length);
+  answer.words = new Array(count);
+  let k = 0 | 0;
+  for (; k + 7 < newcount; k += 8) {
+    answer[k] = this.words[k] & ~otherbitmap.words[k];
+    answer[k + 1] = this.words[k + 1] & ~otherbitmap.words[k + 1];
+    answer[k + 2] = this.words[k + 2] & ~otherbitmap.words[k + 2];
+    answer[k + 3] = this.words[k + 3] & ~otherbitmap.words[k + 3];
+    answer[k + 4] = this.words[k + 4] & ~otherbitmap.words[k + 4];
+    answer[k + 5] = this.words[k + 5] & ~otherbitmap.words[k + 5];
+    answer[k + 6] = this.words[k + 6] & ~otherbitmap.words[k + 6];
+    answer[k + 7] = this.words[k + 7] & ~otherbitmap.words[k + 7];
+  }
+  for (; k < newcount; ++k) {
+    answer[k] = this.words[k] & ~otherbitmap.words[k];
+  }
+  return answer;
+};
+
+// Computes the difference between this bitset and another one,
 // the other bitset is modified (and returned by the function)
 // (for this set A and other set B,
 //   this computes B = A - B  and returns B)
@@ -350,14 +373,8 @@ FastBitSet.prototype.difference2 = function (otherbitmap) {
   for (k = this.words.length - 1; k >= mincount; --k) {
     otherbitmap.words[k] = this.words[k];
   }
-  otherbitmap.words = otherbitmap.words.slice(0, this.words.length);
+  otherbitmap.words.length = this.words.length;
   return otherbitmap;
-};
-
-// Computes the difference between this bitset and another one,
-// a new bitmap is generated
-FastBitSet.prototype.new_difference = function (otherbitmap) {
-  return this.clone().difference(otherbitmap); // should be fast enough
 };
 
 // Computes the size of the difference between this bitset and another one

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -59,7 +59,7 @@ function FastBitSet(iterable) {
 }
 
 // Creates a bitmap from words
-FastBitSet.prototype.fromWords = function (words) {
+FastBitSet.fromWords = function (words) {
   const bitSet = Object.create(FastBitSet.prototype);
   bitSet.words = words;
   return bitSet;

--- a/FastBitSet.js
+++ b/FastBitSet.js
@@ -329,24 +329,7 @@ FastBitSet.prototype.difference = function (otherbitmap) {
 // Computes the difference between this bitset and another one,
 // a new bitmap is generated
 FastBitSet.prototype.new_difference = function (otherbitmap) {
-  const answer = Object.create(FastBitSet.prototype);
-  const count = Math.min(this.words.length, otherbitmap.words.length);
-  answer.words = new Array(count);
-  let k = 0 | 0;
-  for (; k + 7 < newcount; k += 8) {
-    answer[k] = this.words[k] & ~otherbitmap.words[k];
-    answer[k + 1] = this.words[k + 1] & ~otherbitmap.words[k + 1];
-    answer[k + 2] = this.words[k + 2] & ~otherbitmap.words[k + 2];
-    answer[k + 3] = this.words[k + 3] & ~otherbitmap.words[k + 3];
-    answer[k + 4] = this.words[k + 4] & ~otherbitmap.words[k + 4];
-    answer[k + 5] = this.words[k + 5] & ~otherbitmap.words[k + 5];
-    answer[k + 6] = this.words[k + 6] & ~otherbitmap.words[k + 6];
-    answer[k + 7] = this.words[k + 7] & ~otherbitmap.words[k + 7];
-  }
-  for (; k < newcount; ++k) {
-    answer[k] = this.words[k] & ~otherbitmap.words[k];
-  }
-  return answer;
+  return this.clone().difference(otherbitmap); // should be fast enough
 };
 
 // Computes the difference between this bitset and another one,

--- a/README.md
+++ b/README.md
@@ -22,25 +22,25 @@ Usage
 ===
 
 ```javascript
-var b = new FastBitSet();// initially empty
+const b = new FastBitSet();// initially empty
 b.add(1);// add the value "1"
 b.has(1); // check that the value is present! (will return true)
 b.add(2);
 console.log(""+b);// should display {1,2}
 b.add(10);
 b.array(); // would return [1,2,10]
-var c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
+let c = new FastBitSet([1,2,3,10]); // create bitset initialized with values 1,2,3,10
 c.difference(b); // from c, remove elements that are in b (modifies c)
 c.difference2(b) // from c, remove elements that are in b (modifies b)
 c.change(b); // c will contain all elements that are in b or in c, but not both (elements that changed)
-var su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
+const su = c.union_size(b);// compute the size of the union (bitsets are unchanged)
 c.union(b); // c will contain all elements that are in c and b
-var out1 = c.new_union(b); // creates a new bitmap that contains everything in c and b
-var out2 = c.new_intersection(b); // creates a new bitmap that contains everything that is in both c and b
-var out3 = c.new_change(b); // creates a new bitmap that contains everything in b or in c, but not both
-var s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
-var s2 = c.difference_size(b);// compute the size of the difference (bitsets are unchanged)
-var s3 = c.change_size(b); // compute the number of elements that are in b but not c, or vice versa
+const out1 = c.new_union(b); // creates a new bitmap that contains everything in c and b
+const out2 = c.new_intersection(b); // creates a new bitmap that contains everything that is in both c and b
+const out3 = c.new_change(b); // creates a new bitmap that contains everything in b or in c, but not both
+const s1 = c.intersection_size(b);// compute the size of the intersection (bitsets are unchanged)
+const s2 = c.difference_size(b);// compute the size of the difference (bitsets are unchanged)
+const s3 = c.change_size(b); // compute the number of elements that are in b but not c, or vice versa
 c.intersects(b); // return true if c intersects with b
 c.intersection(b); // c will only contain elements that are in both c and b
 c = b.clone(); // create a (deep) copy of b and assign it to c.

--- a/benchmark/test.js
+++ b/benchmark/test.js
@@ -880,6 +880,7 @@ function AndNotInplaceBench() {
   const b1 = new FastBitSet();
   const bb1 = new FastBitSet();
   const tb1 = new TypedFastBitSet();
+  const tbb1 = new TypedFastBitSet();
   let bs1 = new BitSet();
   const bt1 = new tBitSet();
   const r1 = new roaring.RoaringBitmap32();
@@ -888,6 +889,7 @@ function AndNotInplaceBench() {
   const b2 = new FastBitSet();
   const bb2 = new FastBitSet();
   const tb2 = new TypedFastBitSet();
+  const tbb2 = new TypedFastBitSet();
   let bs2 = new BitSet();
   const bt2 = new tBitSet();
   const fb2 = new fBitSet(largegap * N + 5);
@@ -931,10 +933,13 @@ function AndNotInplaceBench() {
       return b1.difference(b2);
     })
     .add("FastBitSet (inplace2)", function () {
-      return bb1.difference(bb2);
+      return bb1.difference2(bb2);
     })
     .add("TypedFastBitSet (inplace)", function () {
       return tb1.difference(tb2);
+    })
+    .add("TypedFastBitSet (inplace2)", function () {
+      return tbb1.difference2(tbb2);
     })
     .add("infusion.BitSet.js (inplace)", function () {
       return bs1.andNot(bs2);
@@ -1129,9 +1134,9 @@ function XORInplaceBench() {
     .add("FastBitSet (inplace)", function () {
       return b1.change(b2);
     })
-    // .add("TypedFastBitSet (inplace)", function () {
-    // return tb1.intersection(tb2);
-    // })
+    .add("TypedFastBitSet (inplace)", function () {
+      return tb1.change(tb2);
+    })
     .add("infusion.BitSet.js (inplace)", function () {
       return bs1.xor(bs2);
     })
@@ -1200,9 +1205,9 @@ function XORBench() {
     .add("FastBitSet (creates new bitset)", function () {
       return b1.new_change(b2);
     })
-    // .add("TypedFastBitSet (creates new bitset)", function () {
-    // return tb1.new_union(tb2);
-    // })
+    .add("TypedFastBitSet (creates new bitset)", function () {
+      return tb1.new_change(tb2);
+    })
     .add("mattkrick.fast-bitset (creates new bitset)", function () {
       return fb1.xor(fb2);
     })


### PR DESCRIPTION
Since I made a similar pull requests to FastBitSet and TypedFastBitSet, I updated the benchmarks to include the new methods, and also found a couple of small bugs and opportunities for optimization.   Interestingly, the new in-place method `difference2` appears to be faster than the original `difference`.

```
FastBitSet (inplace) x 3,414 ops/sec ±0.57% (98 runs sampled)
FastBitSet (inplace2) x 3,702 ops/sec ±0.28% (99 runs sampled)
```

@lemire the new benchmarks for `TypedFastBitSet` will not work until the NPM repository is updated.  thanks!!!
